### PR TITLE
Fix the error in validateCredential func by changing the dot('.') value in the hash

### DIFF
--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -19,7 +19,10 @@ export const encryptCredential = async (password: string): Promise<string> =>
       if (err) {
         return reject(err);
       }
+      // Fix the 404 ERROR that occurs when the hash contains 'slash' or 'dot' value
       hash = hash.replace(/\//g, 'slash');
+      hash = hash.replace(/\.$/g, 'dot');
+
       resolve(hash);
     });
   });
@@ -28,7 +31,10 @@ export const validateCredential = async (
   value: string,
   hashedValue: string,
 ): Promise<boolean> => new Promise<boolean>((resolve, reject) => {
+  // Fix the 404 ERROR that occurs when the hash contains 'slash' or 'dot' value
   hashedValue = hashedValue.replace(/slash/g, '/');
+  hashedValue = hashedValue.replace(/dot$/g, '.');
+
   bcrypt.compare(value, hashedValue, (err, res) => {
     if (err) {
       return reject(err);


### PR DESCRIPTION
## Specify project
hackatalk-server

<br />


## Description

In the current email verification process, hackatalk-server send an email to a user with a link which contains hashed value. We've used bcrypt as a password-hashing function and sometimes bcrypt make a hashed value that ends with '.' (dot).
When this happens, the user only sees the page with the error message when visiting the link. Since the link with blue highlight underline doesn't contain '.'

<br />


## Solution

Replace '.' with characters 'dot' in encryptCredential func and then turn 'slash' back to '/' in validateCredential func.

**Before**

https://hackatalkserver.azurewebsites.net/verify_email/hackatalk%40gmail.com/%242a%2410%24RC6i1mCuUQURHxOpCeExl.keKCgTiDzQ3yodnDO7slash60pkN2BLzOO. 


**After**

https://hackatalkserver.azurewebsites.net/verify_email/hackatalk%40gmail.com/%242a%2410%24RC6i1mCuUQURHxOpCeExl.keKCgTiDzQ3yodnDO7slash60pkN2BLzOOdot



<br />


## Related Issues

https://github.com/dooboolab/hackatalk-server/pull/90

<br />


## Checklist

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
