### PR TITLE
Migrate to fetchQuery since preloadQuery wont handle error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import AsyncStorage from '@react-native-community/async-storage';
 import { LoadingIndicator } from 'dooboo-ui';
 import RootNavigator from './components/navigation/RootStackNavigator';
+import SplashModule from './utils/splash';
 import { User } from 'types/graphql';
 import { initializeEThree } from './utils/virgil';
 
@@ -54,6 +55,7 @@ function AppWithTheme(): ReactElement {
     await initializeEThree(me.id);
     setUser(me as User);
     setLoading(false);
+    SplashModule.hide(300);
   };
 
   useEffect(() => {
@@ -69,6 +71,7 @@ function AppWithTheme(): ReactElement {
         error: (error: any) => {
           console.log('error', error);
           setLoading(false);
+          SplashModule.hide(300);
         },
         next: (data) => {
           if (data.me) {

--- a/client/src/components/screen/SignIn.tsx
+++ b/client/src/components/screen/SignIn.tsx
@@ -21,7 +21,6 @@ import { AuthStackNavigationProps } from '../navigation/AuthStackNavigator';
 import Config from 'react-native-config';
 import { EditTextInputType } from 'dooboo-ui/EditText';
 import SocialSignInButton from '../shared/SocialSignInButton';
-import SplashModule from '../../utils/splash';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
 import { initializeEThree } from '../../utils/virgil';
@@ -238,10 +237,6 @@ function SignIn(props: Props): ReactElement {
 
   const animating = useValue<number>(0);
   const clock = useClock();
-
-  useEffect(() => {
-    SplashModule.hide(500);
-  }, []);
 
   useCode(() => block([delay(set(animating, 1), 100)]), []);
 

--- a/client/src/providers/AuthProvider.tsx
+++ b/client/src/providers/AuthProvider.tsx
@@ -35,7 +35,7 @@ type Reducer = (state: State, action: Action) => State;
 const setUser = (dispatch: React.Dispatch<SetUserAction>) => (
   authUser: User,
 ): void => {
-  if (!authUser) Relay.init();
+  // if (!authUser) Relay.init();
   dispatch({
     type: ActionType.SetUser,
     payload: { user: authUser, relay: Relay.environment },

--- a/client/src/relay/fetch.ts
+++ b/client/src/relay/fetch.ts
@@ -23,7 +23,7 @@ const fetchGraphQL: FetchFunction = async (request, variables) => {
   return fetch(GRAPHQL_URL, config)
     .then((response) => response.json())
     .catch((err) => {
-      console.log('graphqlError', err);
+      throw new Error(err);
     });
 };
 


### PR DESCRIPTION
## Specify project
Client

## Description

![login](https://user-images.githubusercontent.com/27461460/86474992-e1338380-bd7e-11ea-8546-fc1b0aea5812.gif)

Now the server is throwing an error when the client queries `me` query to the server by the [graphql-shield](https://github.com/maticzav/graphql-shield) error handler. This error handling doesn't work well in `relay-hook` so I've managed to change this to `fetchQuery` for now. This works quite well as shown above.

However, there is one more problem left that needs consideration.

![logout](https://user-images.githubusercontent.com/27461460/86474988-de389300-bd7e-11ea-9b5b-6a9a0576d833.gif)

The problem arises when I try to reset `relay` environment after fetching `me` query in [ProfileUpdate] screen with `preloadQuery`. I am hesitating if I need to change this into `fetchQuery` too.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
