### PR TITLE
Implement social sign in on both server and client sides

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -1,3 +1,5 @@
+scalar Auth
+
 type AuthPayload {
   token: String!
   user: User!
@@ -24,12 +26,15 @@ scalar Gender
 type Mutation {
   signUp(user: UserCreateInput): User!
   signInEmail(email: String!, password: String!): AuthPayload!
+  signInWithFacebook(accessToken: String!): AuthPayload!
+  signInWithGoogle(accessToken: String!): AuthPayload!
   sendVerification(email: String!): Boolean!
   updateProfile(user: UserUpdateInput): User!
   findPassword(email: String!): Boolean!
   changeEmailPassword(password: String!, newPassword: String!): Boolean!
   createNotification(token: String!, device: String, os: String): Notification!
   deleteNotification(id: Int!): Notification
+  singleUpload(file: Upload, dir: String): String
 }
 
 type Notification {
@@ -66,7 +71,7 @@ type User {
   nickname: String
   thumbURL: String
   photoURL: String
-  birthDay: DateTime
+  birthday: DateTime
   gender: Gender
   phone: String
   statusMessage: String

--- a/client/src/__generated__/SocialSignInButtonFacebookSignInMutation.graphql.ts
+++ b/client/src/__generated__/SocialSignInButtonFacebookSignInMutation.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SocialSignInButtonFacebookSignInMutationVariables = {
+    token: string;
+};
+export type SocialSignInButtonFacebookSignInMutationResponse = {
+    readonly signInWithFacebook: {
+        readonly token: string;
+        readonly user: {
+            readonly id: string;
+        };
+    };
+};
+export type SocialSignInButtonFacebookSignInMutation = {
+    readonly response: SocialSignInButtonFacebookSignInMutationResponse;
+    readonly variables: SocialSignInButtonFacebookSignInMutationVariables;
+};
+
+
+
+/*
+mutation SocialSignInButtonFacebookSignInMutation(
+  $token: String!
+) {
+  signInWithFacebook(accessToken: $token) {
+    token
+    user {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "token"
+        } as any)
+    ], v1 = [
+        ({
+            "alias": null,
+            "args": [
+                {
+                    "kind": "Variable",
+                    "name": "accessToken",
+                    "variableName": "token"
+                }
+            ],
+            "concreteType": "AuthPayload",
+            "kind": "LinkedField",
+            "name": "signInWithFacebook",
+            "plural": false,
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "token",
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "id",
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                }
+            ],
+            "storageKey": null
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "SocialSignInButtonFacebookSignInMutation",
+            "selections": (v1 /*: any*/),
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "SocialSignInButtonFacebookSignInMutation",
+            "selections": (v1 /*: any*/)
+        },
+        "params": {
+            "cacheID": "fe92e0a4a508022f173f8b7aa65fa5d8",
+            "id": null,
+            "metadata": {},
+            "name": "SocialSignInButtonFacebookSignInMutation",
+            "operationKind": "mutation",
+            "text": "mutation SocialSignInButtonFacebookSignInMutation(\n  $token: String!\n) {\n  signInWithFacebook(accessToken: $token) {\n    token\n    user {\n      id\n    }\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = '67bef5067ac978f18537b63abe53716d';
+export default node;

--- a/client/src/__generated__/SocialSignInButtonGoogleSignInMutation.graphql.ts
+++ b/client/src/__generated__/SocialSignInButtonGoogleSignInMutation.graphql.ts
@@ -1,0 +1,115 @@
+/* tslint:disable */
+/* eslint-disable */
+
+import { ConcreteRequest } from "relay-runtime";
+export type SocialSignInButtonGoogleSignInMutationVariables = {
+    token: string;
+};
+export type SocialSignInButtonGoogleSignInMutationResponse = {
+    readonly signInWithGoogle: {
+        readonly token: string;
+        readonly user: {
+            readonly id: string;
+        };
+    };
+};
+export type SocialSignInButtonGoogleSignInMutation = {
+    readonly response: SocialSignInButtonGoogleSignInMutationResponse;
+    readonly variables: SocialSignInButtonGoogleSignInMutationVariables;
+};
+
+
+
+/*
+mutation SocialSignInButtonGoogleSignInMutation(
+  $token: String!
+) {
+  signInWithGoogle(accessToken: $token) {
+    token
+    user {
+      id
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "token"
+        } as any)
+    ], v1 = [
+        ({
+            "alias": null,
+            "args": [
+                {
+                    "kind": "Variable",
+                    "name": "accessToken",
+                    "variableName": "token"
+                }
+            ],
+            "concreteType": "AuthPayload",
+            "kind": "LinkedField",
+            "name": "signInWithGoogle",
+            "plural": false,
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "token",
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "user",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "id",
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                }
+            ],
+            "storageKey": null
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "SocialSignInButtonGoogleSignInMutation",
+            "selections": (v1 /*: any*/),
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "SocialSignInButtonGoogleSignInMutation",
+            "selections": (v1 /*: any*/)
+        },
+        "params": {
+            "cacheID": "81b9a31bae5c1ceab9aa498c0e535143",
+            "id": null,
+            "metadata": {},
+            "name": "SocialSignInButtonGoogleSignInMutation",
+            "operationKind": "mutation",
+            "text": "mutation SocialSignInButtonGoogleSignInMutation(\n  $token: String!\n) {\n  signInWithGoogle(accessToken: $token) {\n    token\n    user {\n      id\n    }\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = '55670a6ac6f2038ced30fbbc7d83aeb6';
+export default node;

--- a/client/src/components/screen/VerifyEmail.tsx
+++ b/client/src/components/screen/VerifyEmail.tsx
@@ -59,7 +59,7 @@ function Page(props: Props): ReactElement {
       Alert.alert(getString('ERROR'), getString('RESENT_VERIFICATION_EMAIL_FAILED'));
     },
     onError: (error: any): void => {
-      showAlertForError(error?.graphQLErrors);
+      showAlertForError(error);
     },
   };
 

--- a/client/src/types/graphql.ts
+++ b/client/src/types/graphql.ts
@@ -7,6 +7,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  Auth: any;
   /**
    * A date string, such as 2007-12-03, compliant with the `full-date` format
    * outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for
@@ -18,6 +19,7 @@ export type Scalars = {
   /** The `Upload` scalar type represents a file upload. */
   Upload: any;
 };
+
 
 export type AuthPayload = {
   __typename?: 'AuthPayload';
@@ -32,43 +34,66 @@ export enum AuthType {
   Apple = 'apple'
 }
 
+
+
+
 export type Mutation = {
   __typename?: 'Mutation';
   signUp: User;
   signInEmail: AuthPayload;
+  signInWithFacebook: AuthPayload;
+  signInWithGoogle: AuthPayload;
   sendVerification: Scalars['Boolean'];
   updateProfile: User;
   findPassword: Scalars['Boolean'];
   changeEmailPassword: Scalars['Boolean'];
   createNotification: Notification;
   deleteNotification?: Maybe<Notification>;
+  singleUpload?: Maybe<Scalars['String']>;
 };
+
 
 export type MutationSignUpArgs = {
   user?: Maybe<UserCreateInput>;
 };
+
 
 export type MutationSignInEmailArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
 };
 
+
+export type MutationSignInWithFacebookArgs = {
+  accessToken: Scalars['String'];
+};
+
+
+export type MutationSignInWithGoogleArgs = {
+  accessToken: Scalars['String'];
+};
+
+
 export type MutationSendVerificationArgs = {
   email: Scalars['String'];
 };
+
 
 export type MutationUpdateProfileArgs = {
   user?: Maybe<UserUpdateInput>;
 };
 
+
 export type MutationFindPasswordArgs = {
   email: Scalars['String'];
 };
+
 
 export type MutationChangeEmailPasswordArgs = {
   password: Scalars['String'];
   newPassword: Scalars['String'];
 };
+
 
 export type MutationCreateNotificationArgs = {
   token: Scalars['String'];
@@ -76,8 +101,15 @@ export type MutationCreateNotificationArgs = {
   os?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationDeleteNotificationArgs = {
   id: Scalars['Int'];
+};
+
+
+export type MutationSingleUploadArgs = {
+  file?: Maybe<Scalars['Upload']>;
+  dir?: Maybe<Scalars['String']>;
 };
 
 export type Notification = {
@@ -102,6 +134,7 @@ export type Query = {
   notifications?: Maybe<Array<Notification>>;
 };
 
+
 export type QueryNotificationsArgs = {
   userId?: Maybe<Scalars['String']>;
 };
@@ -112,13 +145,16 @@ export type Subscription = {
   userUpdated: User;
 };
 
+
 export type SubscriptionUserSignedInArgs = {
   userId: Scalars['String'];
 };
 
+
 export type SubscriptionUserUpdatedArgs = {
   userId: Scalars['String'];
 };
+
 
 export type User = {
   __typename?: 'User';
@@ -128,7 +164,7 @@ export type User = {
   nickname?: Maybe<Scalars['String']>;
   thumbURL?: Maybe<Scalars['String']>;
   photoURL?: Maybe<Scalars['String']>;
-  birthDay?: Maybe<Scalars['DateTime']>;
+  birthday?: Maybe<Scalars['DateTime']>;
   gender?: Maybe<Scalars['Gender']>;
   phone?: Maybe<Scalars['String']>;
   statusMessage?: Maybe<Scalars['String']>;

--- a/client/web-build/register-service-worker.js
+++ b/client/web-build/register-service-worker.js
@@ -1,1 +1,14 @@
-"serviceWorker"in navigator&&window.addEventListener("load",(function(){navigator.serviceWorker.register("/expo-service-worker.js",{scope:"/"}).then((function(e){})).catch((function(e){console.info("Failed to register service-worker",e)}))}));
+/* eslint-env browser */
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function () {
+    navigator.serviceWorker
+      .register('/expo-service-worker.js', { scope: '/' })
+      .then(function (info) {
+        // console.info('Registered service-worker', info);
+      })
+      .catch(function (error) {
+        console.info('Failed to register service-worker', error);
+      });
+  });
+}

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -68,7 +68,7 @@ interface GoogleUser {
 
 export const verifyGoogleId = async (token: string): Promise<GoogleUser> => {
   const { data } = await axios.get(
-      `https://oauth2.googleapis.com/tokeninfo?${token}`,
+     `https://www.googleapis.com/oauth2/v3/userinfo?access_token=${token}`,
   );
 
   return data as GoogleUser;


### PR DESCRIPTION
## Specify project
Both

## Description

Integrate `googleSignIn` and `facebookSignIn` mutation on client. Also fixes `google` verify token url on server side.


## Tests

I added the following tests:

_Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage](https://codecov.io/gh/dooboolab/hackatalk)._

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] Run `yarn lint && yarn tsc`
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [ ] I am willing to follow-up on review comments in a timely manner.
