### PR TITLE
Implement Apple signin on both server and client

### DIFF
--- a/client/.ncurc.json
+++ b/client/.ncurc.json
@@ -7,6 +7,6 @@
     "react-native-gesture-handler",
     "react-native-reanimated",
     "react-native-safe-area-context",
-    "@types/react-native",
+    "@types/react-native"
   ]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -59,7 +59,7 @@
     "expo-localization": "~8.2.1",
     "expo-permissions": "^9.0.1",
     "expo-updates": "~0.2.12",
-    "expo-web-browser": "^8.3.1",
+    "expo-web-browser": "~8.3.1",
     "graphql": "^15.3.0",
     "i18n-js": "^3.7.1",
     "immer": "^7.0.7",

--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -27,6 +27,7 @@ type Mutation {
   signUp(user: UserCreateInput): User!
   signInEmail(email: String!, password: String!): AuthPayload!
   signInWithFacebook(accessToken: String!): AuthPayload!
+  signInWithApple(accessToken: String!): AuthPayload!
   signInWithGoogle(accessToken: String!): AuthPayload!
   sendVerification(email: String!): Boolean!
   updateProfile(user: UserUpdateInput): User!

--- a/client/src/__generated__/SignInAppleMutation.graphql.ts
+++ b/client/src/__generated__/SignInAppleMutation.graphql.ts
@@ -2,38 +2,32 @@
 /* eslint-disable */
 
 import { ConcreteRequest } from "relay-runtime";
-export type SocialSignInButtonFacebookSignInMutationVariables = {
-    token: string;
+export type SignInAppleMutationVariables = {
+    idToken: string;
 };
-export type SocialSignInButtonFacebookSignInMutationResponse = {
-    readonly signInWithFacebook: {
+export type SignInAppleMutationResponse = {
+    readonly signInWithApple: {
         readonly token: string;
         readonly user: {
             readonly id: string;
-            readonly email: string | null;
-            readonly name: string | null;
-            readonly nickname: string | null;
         };
     };
 };
-export type SocialSignInButtonFacebookSignInMutation = {
-    readonly response: SocialSignInButtonFacebookSignInMutationResponse;
-    readonly variables: SocialSignInButtonFacebookSignInMutationVariables;
+export type SignInAppleMutation = {
+    readonly response: SignInAppleMutationResponse;
+    readonly variables: SignInAppleMutationVariables;
 };
 
 
 
 /*
-mutation SocialSignInButtonFacebookSignInMutation(
-  $token: String!
+mutation SignInAppleMutation(
+  $idToken: String!
 ) {
-  signInWithFacebook(accessToken: $token) {
+  signInWithApple(accessToken: $idToken) {
     token
     user {
       id
-      email
-      name
-      nickname
     }
   }
 }
@@ -44,7 +38,7 @@ const node: ConcreteRequest = (function () {
         ({
             "defaultValue": null,
             "kind": "LocalArgument",
-            "name": "token"
+            "name": "idToken"
         } as any)
     ], v1 = [
         ({
@@ -53,12 +47,12 @@ const node: ConcreteRequest = (function () {
                 {
                     "kind": "Variable",
                     "name": "accessToken",
-                    "variableName": "token"
+                    "variableName": "idToken"
                 }
             ],
             "concreteType": "AuthPayload",
             "kind": "LinkedField",
-            "name": "signInWithFacebook",
+            "name": "signInWithApple",
             "plural": false,
             "selections": [
                 {
@@ -82,27 +76,6 @@ const node: ConcreteRequest = (function () {
                             "kind": "ScalarField",
                             "name": "id",
                             "storageKey": null
-                        },
-                        {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "email",
-                            "storageKey": null
-                        },
-                        {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "name",
-                            "storageKey": null
-                        },
-                        {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "nickname",
-                            "storageKey": null
                         }
                     ],
                     "storageKey": null
@@ -116,7 +89,7 @@ const node: ConcreteRequest = (function () {
             "argumentDefinitions": (v0 /*: any*/),
             "kind": "Fragment",
             "metadata": null,
-            "name": "SocialSignInButtonFacebookSignInMutation",
+            "name": "SignInAppleMutation",
             "selections": (v1 /*: any*/),
             "type": "Mutation",
             "abstractKey": null
@@ -125,18 +98,18 @@ const node: ConcreteRequest = (function () {
         "operation": {
             "argumentDefinitions": (v0 /*: any*/),
             "kind": "Operation",
-            "name": "SocialSignInButtonFacebookSignInMutation",
+            "name": "SignInAppleMutation",
             "selections": (v1 /*: any*/)
         },
         "params": {
-            "cacheID": "cecbee289e8cf5a4a313c95ffe414a4c",
+            "cacheID": "35c138f5251cbee5640bf254e09d3be9",
             "id": null,
             "metadata": {},
-            "name": "SocialSignInButtonFacebookSignInMutation",
+            "name": "SignInAppleMutation",
             "operationKind": "mutation",
-            "text": "mutation SocialSignInButtonFacebookSignInMutation(\n  $token: String!\n) {\n  signInWithFacebook(accessToken: $token) {\n    token\n    user {\n      id\n      email\n      name\n      nickname\n    }\n  }\n}\n"
+            "text": "mutation SignInAppleMutation(\n  $idToken: String!\n) {\n  signInWithApple(accessToken: $idToken) {\n    token\n    user {\n      id\n    }\n  }\n}\n"
         }
     } as any;
 })();
-(node as any).hash = '4136b1130e4314532ce436342c61b6f9';
+(node as any).hash = 'e99bef1cc310ea16a7901ce9d8cc07ef';
 export default node;

--- a/client/src/components/shared/SocialSignInButton.tsx
+++ b/client/src/components/shared/SocialSignInButton.tsx
@@ -1,6 +1,6 @@
 import * as AuthSession from 'expo-auth-session';
 
-import { Alert, Platform, View } from 'react-native';
+import { Alert, AsyncStorage, Platform, View } from 'react-native';
 import { AuthType, User } from '../../types/graphql';
 import React, { FC, ReactElement, useState } from 'react';
 import type {
@@ -134,7 +134,10 @@ const SocialSignInButton: FC<Props> = ({
             variables: { token: accessToken },
             onCompleted: async (response: SocialSignInButtonGoogleSignInMutationResponse): Promise<void> => {
               if (response.signInWithGoogle) {
-                if (onUserCreated) onUserCreated(response.signInWithGoogle.user);
+                const { user, token } = response.signInWithGoogle;
+                await AsyncStorage.setItem('token', token);
+
+                if (onUserCreated) onUserCreated(user);
                 return;
               }
               Alert.alert(getString('ERROR'), getString('ERROR_OCCURED'));
@@ -153,7 +156,10 @@ const SocialSignInButton: FC<Props> = ({
           variables: { token: accessToken },
           onCompleted: async (response: SocialSignInButtonFacebookSignInMutationResponse): Promise<void> => {
             if (response.signInWithFacebook) {
-              if (onUserCreated) onUserCreated(response.signInWithFacebook.user);
+              const { user, token } = response.signInWithFacebook;
+              await AsyncStorage.setItem('token', token);
+
+              if (onUserCreated) onUserCreated(user);
               return;
             }
             Alert.alert(getString('ERROR'), getString('ERROR_OCCURED'));
@@ -215,7 +221,7 @@ const SocialSignInButton: FC<Props> = ({
     leftElement={
       <View style={{ marginRight: 6 }}>{svgIcon}</View>
     }
-    isLoading={signingIn}
+    isLoading={isFacebookInFlight || isGoogleInFlight || signingIn}
     indicatorColor={theme.primary}
     onPress={signIn}
     text={getString('SIGN_IN_WITH_FACEBOOK')}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8231,7 +8231,7 @@ expo-updates@~0.2.12:
     fbemitter "^2.1.1"
     uuid "^3.4.0"
 
-expo-web-browser@^8.3.1:
+expo-web-browser@^8.3.1, expo-web-browser@~8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/expo-web-browser/-/expo-web-browser-8.3.1.tgz#c88cc349dfa1db31cfdbe365753b6840054d0152"
   integrity sha512-mDxSNpc/Ww/RX6MhmPRUWo2xNi8HGZ1TDMqIjTvUzrL7pGG9VerX0EDMhfLgo6c7KVOY1ngbTyybApZTXgPCOQ==

--- a/server/package.json
+++ b/server/package.json
@@ -50,7 +50,8 @@
     "jsonwebtoken": "^8.5.1",
     "multer": "^1.4.2",
     "nexus": "^0.25.0",
-    "nexus-plugin-prisma": "^0.16.1"
+    "nexus-plugin-prisma": "^0.16.1",
+    "node-rsa": "^1.1.1"
   },
   "devDependencies": {
     "@types/bcrypt-nodejs": "^0.0.31",
@@ -62,6 +63,7 @@
     "@types/jsonwebtoken": "8.5.0",
     "@types/multer": "^1.4.3",
     "@types/node": "^14.0.22",
+    "@types/node-rsa": "^1.0.0",
     "@types/ws": "7.2.6",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",

--- a/server/src/types/resolvers/User/mutation.ts
+++ b/server/src/types/resolvers/User/mutation.ts
@@ -6,6 +6,7 @@ import {
   getUserId,
   validateCredential,
   validateEmail,
+  verifyAppleId,
   verifyFacebookId,
   verifyGoogleId,
 } from '../../../utils/auth';
@@ -213,6 +214,26 @@ export const signInWithFacebook = mutationField('signInWithFacebook', {
         authType: AuthType.facebook,
         name,
         email: email || `${facebookId}@facebook.com`,
+      },
+      ctx,
+    );
+  },
+});
+
+export const signInWithApple = mutationField('signInWithApple', {
+  type: 'AuthPayload',
+  args: {
+    accessToken: stringArg({ nullable: false }),
+  },
+  resolve: async (_parent, { accessToken }, ctx) => {
+    const { sub, email } = await verifyAppleId(accessToken);
+
+    return signInWithSocialAccount(
+      {
+        socialId: sub,
+        authType: AuthType.apple,
+        name: '',
+        email: email,
       },
       ctx,
     );

--- a/server/tests/setup/queries.ts
+++ b/server/tests/setup/queries.ts
@@ -52,6 +52,19 @@ export const signInWithFacebook = /* GraphQL */`
   }
 `;
 
+export const signInWithApple = /* GraphQL */`
+  mutation signInWithApple($accessToken: String!) {
+    signInWithApple(accessToken: $accessToken) {
+      token
+      user {
+        id
+        name
+        email
+      }
+    }
+  }
+`;
+
 export const updateProfileMutation = /* GraphQL */`
   mutation updateProfile($user: UserUpdateInput) {
     updateProfile(user: $user) {

--- a/server/tests/user.test.ts
+++ b/server/tests/user.test.ts
@@ -5,6 +5,7 @@ import { apolloClient, testHost } from './setup/testSetup';
 import {
   meQuery,
   signInEmailMutation,
+  signInWithApple,
   signInWithFacebook,
   signInWithGoogle,
   signUpMutation,
@@ -100,6 +101,26 @@ describe('Resolver - User', () => {
     expect(response.signInWithFacebook).toHaveProperty('token');
     expect(response.signInWithFacebook).toHaveProperty('user');
     expect(response.signInWithFacebook.user.email).toEqual('facebook@email.com');
+  });
+
+  it('should signIn user wigh Apple', async () => {
+    const variables = {
+      accessToken: 'apple_user_token',
+    };
+
+    jest
+      .spyOn(AuthUtils, 'verifyAppleId')
+      // @ts-ignore
+      .mockImplementation(() => Promise.resolve({
+        sub: 'apple_user_token',
+        email: 'apple@email.com',
+      }));
+
+    const response = await request(testHost, signInWithApple, variables);
+    expect(response).toHaveProperty('signInWithApple');
+    expect(response.signInWithApple).toHaveProperty('token');
+    expect(response.signInWithApple).toHaveProperty('user');
+    expect(response.signInWithApple.user.email).toEqual('apple@email.com');
   });
 
   it('should signIn user with email', async () => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1112,6 +1112,13 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
+"@types/node-rsa@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/node-rsa/-/node-rsa-1.0.0.tgz#4432df6227c5de734f5f0fbea2420ffb51c51e44"
+  integrity sha512-9hTSXhGDKotpq5XCm+r7wMgt5gl6bGH6VS/sV9bsKda4JmJYyOCdTenSkTUh7zsOihm2oCm5o2ZdfpUIGYKLzQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "13.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.4.tgz#1581d6c16e3d4803eb079c87d4ac893ee7501c2c"
@@ -1846,7 +1853,7 @@ arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asn1@~0.2.3:
+asn1@^0.2.4, asn1@~0.2.3:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.4.tgz#8d2475dfab553bb33e77b54e59e880bb8ce23136"
   integrity sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
@@ -5860,6 +5867,13 @@ node-pre-gyp@^0.13.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-rsa@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-rsa/-/node-rsa-1.1.1.tgz#efd9ad382097782f506153398496f79e4464434d"
+  integrity sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==
+  dependencies:
+    asn1 "^0.2.4"
 
 nodemon@^2.0.4:
   version "2.0.4"


### PR DESCRIPTION
## Specify project
Both.

## Description

Implement [sign in with apple](https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/authenticating_users_with_sign_in_with_apple). This currently works on `iOS` only.


## Tests

WIP

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
