### PR TITLE
Make email titles translatable

### DIFF
--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -13,5 +13,7 @@
   "PASSWORD": "Password",
   "CHANGE_PASSWORD": "Change password",
   "PW_CHANGED_TITLE": "Password has changed",
-  "PW_CHANGED": "The password for your account has changed."
+  "PW_CHANGED": "The password for your account has changed.",
+  "VERIFICATION_EMAIL_SUBJECT": "[HackaTalk] Verify your email address!",
+  "PASSWORD_RESET_EMAIL_SUBJECT": "[HackaTalk] Reset your password!"
 }

--- a/server/locales/ko.json
+++ b/server/locales/ko.json
@@ -13,5 +13,7 @@
   "PASSWORD": "비밀번호",
   "CHANGE_PASSWORD": "비밀번호 변경하기",
   "PW_CHANGED_TITLE": "비밀번호 변경 완료",
-  "PW_CHANGED": "비밀번호가 변경되었습니다. 변경된 임시 비밀번호를 이용하여 로그인해주세요."
+  "PW_CHANGED": "비밀번호가 변경되었습니다. 변경된 임시 비밀번호를 이용하여 로그인해주세요.",
+  "VERIFICATION_EMAIL_SUBJECT": "[HackaTalk] 이메일 주소를 인증해주세요!",
+  "PASSWORD_RESET_EMAIL_SUBJECT": "[HackaTalk] 비밀번호를 재설정하세요!"
 }

--- a/server/src/types/resolvers/User/mutation.ts
+++ b/server/src/types/resolvers/User/mutation.ts
@@ -280,7 +280,7 @@ export const sendVerification = mutationField('sendVerification', {
       const msg = {
         to: email,
         from: 'noreply@hackatalk.dev',
-        subject: '[HackaTalk] Verify your email address!',
+        subject: ctx.request.req.t('VERIFICATION_EMAIL_SUBJECT'),
         html,
       };
       await SendGridMail.send(msg);
@@ -330,7 +330,7 @@ export const findPassword = mutationField('findPassword', {
     const msg = {
       to: email,
       from: 'noreply@hackatalk.dev',
-      subject: '[HackaTalk] Reset your password!',
+      subject: ctx.request.req.t('PASSWORD_RESET_EMAIL_SUBJECT'),
       html: getPasswordResetHTML(verificationToken, password, ctx.request.req),
     };
     try {


### PR DESCRIPTION
## Specify project
It's server-side issue

## Description

This pr makes email, like email verification mail, subjects translatable.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
