### PR TITLE
Use SENDGRID_EMAIL Environment Variable

### DIFF
--- a/server/dotenv/dev.env
+++ b/server/dotenv/dev.env
@@ -2,6 +2,7 @@ JWT_SECRET=dooboolab
 DATABASE_URL="postgresql://postgres:dooboolab0!@localhost:5432/postgres?schema=hackatalk"
 
 SENDGRID_API_KEY=
+SENDGRID_EMAIL=
 STORAGE_ACCOUNT=
 STORAGE_KEY=
 STORAGE_ENDPOINT=https://dooboolabstorage.z32.web.core.windows.net

--- a/server/dotenv/test.env
+++ b/server/dotenv/test.env
@@ -2,6 +2,7 @@ JWT_SECRET=dooboolab
 DATABASE_URL="postgresql://postgres:dooboolab0!@localhost:5432/postgres?schema=test"
 
 SENDGRID_API_KEY=
+SENDGRID_EMAIL=
 STORAGE_ACCOUNT=
 STORAGE_KEY=
 STORAGE_ENDPOINT=

--- a/server/src/types/resolvers/User/mutation.ts
+++ b/server/src/types/resolvers/User/mutation.ts
@@ -30,6 +30,8 @@ import SendGridMail from '@sendgrid/mail';
 import generator from 'generate-password';
 import { sign } from 'jsonwebtoken';
 
+const { SENDGRID_EMAIL } = process.env;
+
 interface SocialUserInput {
   socialId: string;
   authType: AuthType;
@@ -279,7 +281,7 @@ export const sendVerification = mutationField('sendVerification', {
       const html = getEmailVerificationHTML(verificationToken, ctx.request.req);
       const msg = {
         to: email,
-        from: 'noreply@hackatalk.dev',
+        from: SENDGRID_EMAIL,
         subject: ctx.request.req.t('VERIFICATION_EMAIL_SUBJECT'),
         html,
       };


### PR DESCRIPTION
Remove hard-coded outbound email address and use an environment variable instead.

## Specify project
Server-side

## Description

When the server issues a verification email, it used to use a hard-coded email address.
This PR is adding an environment variable `SENDGRID_EMAIL` so that developers can use their own email addresses
to send verification emails.

## Related Issues

Resolve #197 

## Tests

There was no existing test for mutation `sendVerification`.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
