### PR TITLE
Resolve Conflicting expo-font Versions

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -52,7 +52,6 @@
     "expo-constants": "^9.1.1",
     "expo-crypto": "~8.2.1",
     "expo-device": "^2.2.1",
-    "expo-font": "^8.2.2",
     "expo-image-manipulator": "^8.2.1",
     "expo-image-picker": "~8.3.0",
     "expo-linear-gradient": "~8.2.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8328,14 +8328,6 @@ expo-file-system@~9.0.1:
   dependencies:
     uuid "^3.4.0"
 
-expo-font@^8.2.2:
-  version "8.2.2"
-  resolved "https://registry.yarnpkg.com/expo-font/-/expo-font-8.2.2.tgz#c67ee8d3841921a907464d67e8098baeed92bacf"
-  integrity sha512-p/a7Ve+3LiR9ofn77U0UuuE6ZQiLVu3M1btiKUDe5efAp48D9GG41AevKQ7YnkfxTDdGJa0ACAtJAVsAD30jGA==
-  dependencies:
-    fbjs "1.0.0"
-    fontfaceobserver "^2.1.0"
-
 expo-font@~8.2.1:
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/expo-font/-/expo-font-8.2.1.tgz#82f9d7f3e96a0ea4376e573b126379aa754ea807"


### PR DESCRIPTION
## Specify project
Client-side

## Description
`expo-font@8.2.1` is a dependency of `expo@38.0.9`.
There was a separate entry for `expo-font@8.2.2` inside `package.json`.
Conflict between `expo-font@8.2.1` and `expo-font@8.2.2` results in an error inside `Settings.tsx` when loading `FontAwesome`:
```
fontFamily "FontAwesome" is not a system font and has not been loaded through Font.loadAsync.

- If you intended to use a system font, make sure you typed the name correctly and that it is supported by your device operating system.

- If this is a custom font, be sure to load it with Font.loadAsync.
```
Remove redundant `expo-font` dependency from `package.json`.

## Related Issues
https://github.com/expo/expo/issues/5507

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
