### PR TITLE
Add Support for React Native Tools Extension

### DIFF
--- a/client/.vscode/launch.json
+++ b/client/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach to packager",
+      "cwd": "${workspaceFolder}",
+      "type": "reactnative",
+      "request": "attach"
+    }
+  ]
+}
+

--- a/client/.vscode/settings.json
+++ b/client/.vscode/settings.json
@@ -23,5 +23,6 @@
   },
   "javascript.preferences.importModuleSpecifier": "relative",
   "typescript.preferences.importModuleSpecifier": "relative",
-  "prettier.configPath": ".prettierrc.js"
+  "prettier.configPath": ".prettierrc.js",
+  "react-native.packager.port": 19001
 }


### PR DESCRIPTION
## Specify project

Client

## Description

Allow remote JS debugging using [React Native Tools](https://marketplace.visualstudio.com/items?itemName=msjsdiag.vscode-react-native) VSCode extension.
Add launch configuration for expo in VSCode.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
