### PR TITLE
Allow to Omit Types in Function Expressions

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -4,5 +4,11 @@ module.exports = {
   rules: {
     'react/display-name': 0,
     '@typescript-eslint/ban-ts-comment': 0,
+    '@typescript-eslint/explicit-function-return-type': [
+      'error',
+      {
+        allowExpressions: true,
+      },
+    ],
   },
 };


### PR DESCRIPTION
Update eslint rules.

## Specify project
Both

## Description
ESLint rule [@typescript-eslint/explicit-function-return-type](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md) requires all function to have return type defined.
Defining return type of arrow functions is often unnecessary, because they are immediately assigned to a typed variable/property anyways (so it is type-safe). Here are 2 examples where this rule is unnecessarily raising error:

1. Returning a clean-up function at the end of `useEffect` call.
![lint](https://user-images.githubusercontent.com/8978815/90489260-01c16c80-e178-11ea-8f03-7ab89381f21c.png)
2. Passing in an event handler for `onPress`.
![lint2](https://user-images.githubusercontent.com/8978815/90489271-07b74d80-e178-11ea-93f0-5eae34bbece7.png)

In both cases, explicitly writing `void` will not increase the type-safety.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
