### PR TITLE
Add A Helper Class to Format Nested Providers

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import type {
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
 import { AuthProvider, useAuthContext } from './providers/AuthProvider';
 import { DeviceProvider, useDeviceContext } from './providers/DeviceProvider';
-import React, { FC, ReactElement, Suspense, useEffect, useState } from 'react';
+import React, { ReactElement, ReactNode, Suspense, useEffect, useState } from 'react';
 import {
   RelayEnvironmentProvider,
   fetchQuery,
@@ -21,6 +21,7 @@ import { ActionSheetProvider } from '@expo/react-native-action-sheet';
 import { AppLoading } from 'expo';
 import { Asset } from 'expo-asset';
 import AsyncStorage from '@react-native-community/async-storage';
+import ComponentWrapper from './utils/ComponentWrapper';
 import Icons from './utils/Icons';
 import { Image } from 'react-native';
 import { LoadingIndicator } from 'dooboo-ui';
@@ -56,7 +57,7 @@ const loadAssetsAsync = async (): Promise<void> => {
   await Promise.all([...imageAssets]);
 };
 
-function AppWithTheme(): ReactElement {
+function App(): ReactElement {
   const environment = useRelayEnvironment();
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -110,9 +111,8 @@ function AppWithTheme(): ReactElement {
   return <RootNavigator />;
 }
 
-function App(): ReactElement {
+function HackatalkThemeProvider(props: { children: ReactElement }): ReactElement {
   const colorScheme = useColorScheme();
-
   return (
     <ThemeProvider
       customTheme={{ light, dark }}
@@ -120,33 +120,28 @@ function App(): ReactElement {
         colorScheme === 'dark' ? ThemeType.DARK : ThemeType.LIGHT
       }
     >
-      <AppWithTheme />
+      {props.children}
     </ThemeProvider>
   );
 }
 
-const RelayProviderWrapper: FC = ({ children }) => {
+function ActionSheetProviderWithChildren(props: { children: ReactNode }): ReactElement {
   return (
-    <RelayEnvironmentProvider environment={relayEnvironment}>
-      <Suspense fallback={<LoadingIndicator />}>
-        <ActionSheetProvider>{children}</ActionSheetProvider>
-      </Suspense>
-    </RelayEnvironmentProvider>
-  );
-};
-
-function ProviderWrapper(): ReactElement {
-  return (
-    <AppearanceProvider>
-      <DeviceProvider>
-        <AuthProvider>
-          <RelayProviderWrapper>
-            <App />
-          </RelayProviderWrapper>
-        </AuthProvider>
-      </DeviceProvider>
-    </AppearanceProvider>
+    <ActionSheetProvider>
+      {props.children}
+    </ActionSheetProvider>
   );
 }
 
-export default ProviderWrapper;
+// Add all required providers for App.
+const WrappedApp = new ComponentWrapper(App)
+  .wrap(HackatalkThemeProvider, {})
+  .wrap(ActionSheetProviderWithChildren, {})
+  .wrap(Suspense, { fallback: <LoadingIndicator /> })
+  .wrap(RelayEnvironmentProvider, { environment: relayEnvironment })
+  .wrap(AuthProvider, {})
+  .wrap(DeviceProvider, {})
+  .wrap(AppearanceProvider, {})
+  .build();
+
+export default WrappedApp;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,7 +7,7 @@ import type {
 import { AppearanceProvider, useColorScheme } from 'react-native-appearance';
 import { AuthProvider, useAuthContext } from './providers/AuthProvider';
 import { DeviceProvider, useDeviceContext } from './providers/DeviceProvider';
-import React, { ReactElement, ReactNode, Suspense, useEffect, useState } from 'react';
+import React, { FC, ReactElement, ReactNode, Suspense, useEffect, useState } from 'react';
 import {
   RelayEnvironmentProvider,
   fetchQuery,
@@ -111,7 +111,7 @@ function App(): ReactElement {
   return <RootNavigator />;
 }
 
-function HackatalkThemeProvider(props: { children: ReactElement }): ReactElement {
+const HackatalkThemeProvider: FC<{ children: ReactElement }> = ({ children }) => {
   const colorScheme = useColorScheme();
   return (
     <ThemeProvider
@@ -120,10 +120,10 @@ function HackatalkThemeProvider(props: { children: ReactElement }): ReactElement
         colorScheme === 'dark' ? ThemeType.DARK : ThemeType.LIGHT
       }
     >
-      {props.children}
+      {children}
     </ThemeProvider>
   );
-}
+};
 
 function ActionSheetProviderWithChildren(props: { children: ReactNode }): ReactElement {
   return (

--- a/client/src/utils/ComponentWrapper.tsx
+++ b/client/src/utils/ComponentWrapper.tsx
@@ -1,0 +1,42 @@
+import React, { ComponentType, ReactElement } from 'react';
+
+/**
+ * Helper class to nest multiple react components
+ * without introducing indentation hell.
+ */
+class ComponentWrapper {
+  private intermediate: ComponentType;
+
+  constructor(SourceComponent: ComponentType) {
+    this.intermediate = SourceComponent;
+  }
+
+  /**
+   * Add another parent component to this.
+   * @param WrapperComponent Outer component.
+   * @param props Default props for wrapper component.
+   * @returns this. For method chaining.
+   */
+  wrap<P>(
+    WrapperComponent: ComponentType<P & { children: ReactElement }>,
+    props: P,
+  ): ComponentWrapper {
+    const Inner = this.intermediate;
+    const Next = (): ReactElement => (
+      <WrapperComponent {...props}>
+        <Inner />
+      </WrapperComponent>
+    );
+    this.intermediate = Next;
+    return this;
+  }
+
+  /**
+   * Return the wrapped (nested) component.
+   */
+  build(): ComponentType {
+    return this.intermediate;
+  }
+}
+
+export default ComponentWrapper;

--- a/client/src/utils/__tests__/ComponentWrapper.test.tsx
+++ b/client/src/utils/__tests__/ComponentWrapper.test.tsx
@@ -1,0 +1,39 @@
+import React, { ComponentType, ReactElement } from 'react';
+import { getByTestId, render } from '@testing-library/react-native';
+
+import ComponentWrapper from '../ComponentWrapper';
+import { View } from 'react-native';
+
+function createTestView(testId: string): ComponentType<{ children: ReactElement }> {
+  return (props: { children?: ReactElement }): ReactElement => (
+    <View testID={testId}>
+      {props.children}
+    </View>
+  );
+}
+
+describe('ComponentWrapper', () => {
+  it('Single level nesting is itself', () => {
+    const Source = createTestView('source');
+    const Wrapped = new ComponentWrapper(Source).build();
+    const { getByTestId } = render(<Wrapped />);
+    expect(getByTestId('source')).toBeTruthy();
+  });
+
+  it('Nest three', () => {
+    const Innermost = createTestView('innermost');
+    const Middle = createTestView('middle');
+    const Outermost = createTestView('outermost');
+    const Wrapped = new ComponentWrapper(Innermost)
+      .wrap(Middle, {})
+      .wrap(Outermost, {})
+      .build();
+    const { container } = render(<Wrapped />);
+    const actualOutermost = getByTestId(container, 'outermost');
+    const actualMiddle = getByTestId(actualOutermost, 'middle');
+    const actualInnermost = getByTestId(actualMiddle, 'innermost');
+    expect(actualOutermost).toBeTruthy();
+    expect(actualMiddle).toBeTruthy();
+    expect(actualInnermost).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Specify project
Client

## Description

Add ComponentWrapper class.
Refactor provider nesting pattern in App.tsx.
This allows flattening 8 levels of nesting, and prevent `XXXProviderWrapper` helper components.

### Before
```ts
const RelayProviderWrapper: FC = ({ children }) => {
  return (
    <RelayEnvironmentProvider environment={relayEnvironment}>
      <Suspense fallback={<LoadingIndicator />}>
        <ActionSheetProvider>{children}</ActionSheetProvider>
      </Suspense>
    </RelayEnvironmentProvider>
  );
};

function ProviderWrapper(): ReactElement {
  return (
    <AppearanceProvider>
      <DeviceProvider>
        <AuthProvider>
          <RelayProviderWrapper>
            <App />
          </RelayProviderWrapper>
        </AuthProvider>
      </DeviceProvider>
    </AppearanceProvider>
  );
}

export default ProviderWrapper;
```

### After
```ts
// Add all required providers for App.
const WrappedApp = new ComponentWrapper(App)
  .wrap(HackatalkThemeProvider, {})
  .wrap(ActionSheetProviderWithChildren, {})
  .wrap(Suspense, { fallback: <LoadingIndicator /> })
  .wrap(RelayEnvironmentProvider, { environment: relayEnvironment })
  .wrap(AuthProvider, {})
  .wrap(DeviceProvider, {})
  .wrap(AppearanceProvider, {})
  .build();

export default WrappedApp;
```

## Tests

I added the following tests:

- ComponentWrapper
    - Single level nesting is itself
    - Nest three

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
