### PR TITLE
Ask Notification Permission on Login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -28,7 +28,6 @@ import { Image } from 'react-native';
 import { LoadingIndicator } from 'dooboo-ui';
 import RootNavigator from './components/navigation/RootStackNavigator';
 import { User } from 'types/graphql';
-import { registerForPushNotificationsAsync } from './utils/noti';
 import relayEnvironment from './relay';
 
 Notifications.setNotificationHandler({
@@ -103,10 +102,6 @@ function App(): ReactElement {
         AsyncStorage.removeItem('token');
         setDevice();
       },
-    });
-
-    registerForPushNotificationsAsync().then((token) => {
-      if (token) { AsyncStorage.setItem('push_token', token); }
     });
   }, []);
 

--- a/client/src/components/screen/SignIn.tsx
+++ b/client/src/components/screen/SignIn.tsx
@@ -33,6 +33,7 @@ import { EditTextInputType } from 'dooboo-ui/EditText';
 import SocialSignInButton from '../shared/SocialSignInButton';
 import StatusBar from '../shared/StatusBar';
 import { getString } from '../../../STRINGS';
+import { registerForPushNotificationsAsync } from '../../utils/noti';
 import styled from 'styled-components/native';
 import { useAuthContext } from '../../providers/AuthProvider';
 
@@ -195,6 +196,9 @@ function SignIn(props: Props): ReactElement {
         }
 
         await AsyncStorage.setItem('token', token);
+        registerForPushNotificationsAsync().then((token) => {
+          if (token) { AsyncStorage.setItem('push_token', token); }
+        });
         const pushToken = await AsyncStorage.getItem('push_token');
 
         if (pushToken) {

--- a/client/src/components/screen/SignIn.tsx
+++ b/client/src/components/screen/SignIn.tsx
@@ -196,8 +196,8 @@ function SignIn(props: Props): ReactElement {
         }
 
         await AsyncStorage.setItem('token', token);
-        registerForPushNotificationsAsync().then((token) => {
-          if (token) { AsyncStorage.setItem('push_token', token); }
+        registerForPushNotificationsAsync().then((pushToken) => {
+          if (pushToken) { AsyncStorage.setItem('push_token', pushToken); }
         });
         const pushToken = await AsyncStorage.getItem('push_token');
 

--- a/client/src/utils/noti.ts
+++ b/client/src/utils/noti.ts
@@ -7,7 +7,7 @@ import { getString } from '../../STRINGS';
 import { showAlertForError } from './common';
 
 export const registerForPushNotificationsAsync = async (): Promise<string | undefined> => {
-  let token;
+  let token: string | undefined;
 
   if (Constants.isDevice) {
     const { status: existingStatus } = await Permissions.getAsync(Permissions.NOTIFICATIONS);
@@ -19,7 +19,6 @@ export const registerForPushNotificationsAsync = async (): Promise<string | unde
     }
 
     if (finalStatus !== 'granted') {
-      showAlertForError(getString('FAILED_GET_PUSH_NOTI'));
       return;
     }
 


### PR DESCRIPTION
## Specify project
Client

## Description

### Current Behavior
Hackatalk asks for permission to push notifications on start.
This is okay on mobile devices, but web requires some kind of user interaction before displaying pop-up dialog for permissions.
Prompt for permission without user interaction will be blocked, and users need to enable permission by themselves (without pop-up prompt).

### Updated Behavior
Ask for notification permission after a successful login.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
