### PR TITLE
Changing error-password text to the string in assets/langs

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,4 @@ firebase-debug*.*
 .firebase
 
 .idea
+.gitmessage.txt

--- a/client/package.json
+++ b/client/package.json
@@ -78,7 +78,7 @@
     "react-native-svg": "12.1.0",
     "react-native-tab-view": "^2.15.1",
     "react-native-web": "^0.13.9",
-    "react-native-webview": "9.4.0",
+    "react-native-webview": "^10.8.3",
     "react-navigation-stack": "^2.8.2",
     "react-relay": "^0.0.0-experimental-183bdd28",
     "react-responsive": "^8.1.0",

--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -164,6 +164,9 @@ type Mutation {
   """
   createChannel(channel: ChannelCreateInput, message: MessageCreateInput): Channel!
 
+  """Find or create channel associated to peer user id."""
+  findOrCreatePrivateChannelId(peerUserId: String!): String!
+
   """
   User leaves [public] channel.
     Users cannot leave the [private] channel

--- a/client/src/components/screen/SignIn.tsx
+++ b/client/src/components/screen/SignIn.tsx
@@ -225,8 +225,8 @@ function SignIn(props: Props): ReactElement {
         setUser(user);
       },
 
-      onError: (error: any): void => {
-        setErrorPassword(error.message);
+      onError: () => {
+        setErrorPassword(getString('PASSWORD_MUST_MATCH'));
       },
     };
 

--- a/client/src/types/graphql.ts
+++ b/client/src/types/graphql.ts
@@ -24,6 +24,8 @@ export type Scalars = {
   Upload: any;
 };
 
+
+
 export type AuthPayload = {
   __typename?: 'AuthPayload';
   token: Scalars['String'];
@@ -52,6 +54,7 @@ export type Channel = {
   memberships?: Maybe<Array<Membership>>;
 };
 
+
 export type ChannelMessagesArgs = {
   first?: Maybe<Scalars['Int']>;
   after?: Maybe<Scalars['String']>;
@@ -65,6 +68,9 @@ export type ChannelCreateInput = {
   userIds?: Maybe<Array<Scalars['String']>>;
 };
 
+
+
+
 export type Friend = {
   __typename?: 'Friend';
   createdAt?: Maybe<Scalars['DateTime']>;
@@ -73,6 +79,7 @@ export type Friend = {
   user?: Maybe<User>;
   friend?: Maybe<User>;
 };
+
 
 export type Membership = {
   __typename?: 'Membership';
@@ -84,6 +91,7 @@ export type Membership = {
   user?: Maybe<User>;
   channel?: Maybe<Channel>;
 };
+
 
 export type Message = {
   __typename?: 'Message';
@@ -124,6 +132,7 @@ export type MessageEdge = {
   node: Message;
 };
 
+
 export type Mutation = {
   __typename?: 'Mutation';
   signUp: User;
@@ -149,12 +158,14 @@ export type Mutation = {
    *   The public channel is something like an open chat while
    *   private channel is all kinds of direct messages.
    *   The [Membership] of private channel will be identical to all users which is (member).
-   *
+   *   
    *   <Optional> The channel can be created with message of [MessageType].
    *   Please becareful when creating message and provide proper [MessageType].
    *   This query will return [Channel] with [Membership] without [Message] that has just created.
    */
   createChannel: Channel;
+  /** Find or create channel associated to peer user id. */
+  findOrCreatePrivateChannelId: Scalars['String'];
   /**
    * User leaves [public] channel.
    *   Users cannot leave the [private] channel
@@ -171,43 +182,53 @@ export type Mutation = {
   deleteMessage?: Maybe<Message>;
 };
 
+
 export type MutationSignUpArgs = {
   user?: Maybe<UserCreateInput>;
 };
+
 
 export type MutationSignInEmailArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
 };
 
+
 export type MutationSignInWithFacebookArgs = {
   accessToken: Scalars['String'];
 };
+
 
 export type MutationSignInWithAppleArgs = {
   accessToken: Scalars['String'];
 };
 
+
 export type MutationSignInWithGoogleArgs = {
   accessToken: Scalars['String'];
 };
+
 
 export type MutationSendVerificationArgs = {
   email: Scalars['String'];
 };
 
+
 export type MutationUpdateProfileArgs = {
   user?: Maybe<UserUpdateInput>;
 };
+
 
 export type MutationFindPasswordArgs = {
   email: Scalars['String'];
 };
 
+
 export type MutationChangeEmailPasswordArgs = {
   password: Scalars['String'];
   newPassword: Scalars['String'];
 };
+
 
 export type MutationCreateNotificationArgs = {
   token: Scalars['String'];
@@ -215,46 +236,61 @@ export type MutationCreateNotificationArgs = {
   os?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationDeleteNotificationArgs = {
   token: Scalars['String'];
 };
+
 
 export type MutationSingleUploadArgs = {
   file?: Maybe<Scalars['Upload']>;
   dir?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationAddFriendArgs = {
   friendId: Scalars['String'];
 };
 
+
 export type MutationDeleteFriendArgs = {
   friendId: Scalars['String'];
 };
+
 
 export type MutationCreateChannelArgs = {
   channel?: Maybe<ChannelCreateInput>;
   message?: Maybe<MessageCreateInput>;
 };
 
+
+export type MutationFindOrCreatePrivateChannelIdArgs = {
+  peerUserId: Scalars['String'];
+};
+
+
 export type MutationLeaveChannelArgs = {
   channelId: Scalars['String'];
 };
+
 
 export type MutationInviteUsersToChannelArgs = {
   channelId: Scalars['String'];
   userIds: Array<Scalars['String']>;
 };
 
+
 export type MutationKickUsersFromChannelArgs = {
   channelId: Scalars['String'];
   userIds: Array<Scalars['String']>;
 };
 
+
 export type MutationCreateMessageArgs = {
   channelId: Scalars['String'];
   message: MessageCreateInput;
 };
+
 
 export type MutationDeleteMessageArgs = {
   id: Scalars['String'];
@@ -301,6 +337,7 @@ export type Query = {
   myChannels?: Maybe<Array<Channel>>;
 };
 
+
 export type QueryUsersArgs = {
   searchText?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -309,9 +346,11 @@ export type QueryUsersArgs = {
   before?: Maybe<Scalars['String']>;
 };
 
+
 export type QueryNotificationsArgs = {
   userId?: Maybe<Scalars['String']>;
 };
+
 
 export type QueryChannelArgs = {
   channelId?: Maybe<Scalars['String']>;
@@ -342,13 +381,16 @@ export type Subscription = {
   userUpdated: User;
 };
 
+
 export type SubscriptionUserSignedInArgs = {
   userId: Scalars['String'];
 };
 
+
 export type SubscriptionUserUpdatedArgs = {
   userId: Scalars['String'];
 };
+
 
 export type User = {
   __typename?: 'User';

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -15368,10 +15368,10 @@ react-native-web@^0.13.9:
     prop-types "^15.6.0"
     react-timer-mixin "^0.13.4"
 
-react-native-webview@9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-9.4.0.tgz#108da34a6c7e1c032dcabc942b7e4947ca1d8028"
-  integrity sha512-BBOFUuza0p04+7fNi7TJmB0arpDJzGxHYwTCgI4vj5n/fl7u4jbm7ETp88mf7lo9lP6C6HGLo38KnEy1aXCQkg==
+react-native-webview@^10.8.3:
+  version "10.8.3"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-10.8.3.tgz#63245fdf39320dbbc67c26e1e305342a51f93d66"
+  integrity sha512-QV3dCGG8xsr/65Rpf2/Khno8fzkyyJKUZpn00y6Wd1hbYRqataZOesCm2ceZS21yXzLLGVHmQlB5/41h3K787Q==
   dependencies:
     escape-string-regexp "2.0.0"
     invariant "2.2.4"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -12,3 +12,4 @@ prisma/.env
 src/generated
 
 .idea
+.gitmessage.txt


### PR DESCRIPTION
## Specify project
Client

## Description

Currently, On the Login(home) page, the text that appears when the password is incorrect was not a predefined string, but an error message in the source code.
Changed the password error message to a predefined string('PASSWORD_MUST_MATCH').

### before
![before](https://user-images.githubusercontent.com/45116772/92312667-d1921e80-effd-11ea-8eda-17b2b3bbc157.png)

### after
* **ENG**
![after1](https://user-images.githubusercontent.com/45116772/92312671-da82f000-effd-11ea-8fbb-aaf5d40022de.png)

* **KOR**
![after2](https://user-images.githubusercontent.com/45116772/92312674-dd7de080-effd-11ea-9745-d9e0f21ce0e5.png)


## Related Issues

The change of src to ./src in PR #231 has been deleted here.
This PR is also related to #233.


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
