### PR TITLE
Add channels field resolver to [User]

### DIFF
--- a/server/src/types/models/User.ts
+++ b/server/src/types/models/User.ts
@@ -32,6 +32,22 @@ export const User = objectType({
     t.model.deletedAt();
     t.list.field('notifications', { type: 'Notification', nullable: true });
 
+    t.list.field('channels', {
+      type: 'Channel',
+      nullable: true,
+      resolve: async (user, args, { prisma }) => {
+        return prisma.channel.findMany({
+          where: {
+            membership: {
+              some: {
+                userId: user.id,
+              },
+            },
+          },
+        });
+      },
+    });
+
     t.list.field('friends', {
       type: 'User',
       nullable: true,

--- a/server/src/types/resolvers/Channel/mutation.ts
+++ b/server/src/types/resolvers/Channel/mutation.ts
@@ -112,7 +112,7 @@ export const createChannel = mutationField('createChannel', {
 });
 
 export const findOrCreatePrivateChannelId = mutationField('findOrCreatePrivateChannelId', {
-  type: 'String',
+  type: 'Channel',
   args: { peerUserId: stringArg({ nullable: false }) },
 
   description: 'Find or create channel associated to peer user id.',
@@ -123,11 +123,11 @@ export const findOrCreatePrivateChannelId = mutationField('findOrCreatePrivateCh
 
     if (existingChannel) {
       changeVisibilityWhenInvisible(userId, existingChannel);
-      return existingChannel.id;
+      return existingChannel;
     }
 
     const channel = await createNewChannel(true, peerUserId);
-    return channel.id;
+    return channel;
   },
 });
 

--- a/server/src/types/resolvers/Channel/mutation.ts
+++ b/server/src/types/resolvers/Channel/mutation.ts
@@ -111,7 +111,7 @@ export const createChannel = mutationField('createChannel', {
   },
 });
 
-export const findOrCreatePrivateChannelId = mutationField('findOrCreatePrivateChannelId', {
+export const findOrCreatePrivateChannel = mutationField('findOrCreatePrivateChannel', {
   type: 'Channel',
   args: { peerUserId: stringArg({ nullable: false }) },
 

--- a/server/tests/resolvers/channel.test.ts
+++ b/server/tests/resolvers/channel.test.ts
@@ -2,6 +2,7 @@ import { GraphQLClient, request } from 'graphql-request';
 import {
   channelQuery,
   createChannel,
+  findOrCreatePrivateChannel,
   inviteToChannel,
   kickFromChannel,
   leaveChannel,
@@ -307,5 +308,30 @@ describe('Resolver - Channel', () => {
     expect(responseMyChannel).toHaveProperty('myChannels');
     // The deletion should happen in `myChannels` query
     expect(responseMyChannel.myChannels).toHaveLength(myChannels.length - 2);
+  });
+
+  let newChannelId: string;
+
+  it('should create private channel if does not exists', async () => {
+    const variables = {
+      peerUserId: friendsId[0],
+    };
+
+    const response = await authClient.request(findOrCreatePrivateChannel, variables);
+    expect(response).toHaveProperty('findOrCreatePrivateChannel');
+    expect(response.findOrCreatePrivateChannel).toHaveProperty('id');
+
+    newChannelId = response.findOrCreatePrivateChannel.id;
+  });
+
+  it('should return private channel it exists', async () => {
+    const variables = {
+      peerUserId: friendsId[0],
+    };
+
+    const response = await authClient.request(findOrCreatePrivateChannel, variables);
+    expect(response).toHaveProperty('findOrCreatePrivateChannel');
+    expect(response.findOrCreatePrivateChannel).toHaveProperty('id');
+    expect(response.findOrCreatePrivateChannel.id).toEqual(newChannelId);
   });
 });

--- a/server/tests/resolvers/user.test.ts
+++ b/server/tests/resolvers/user.test.ts
@@ -127,6 +127,7 @@ describe('Resolver - User', () => {
       expect(response2.signInEmail.user.gender).toEqual(subscriptionValue.gender);
       expect(response2.signInEmail.user.createdAt).toEqual(subscriptionValue.createdAt);
     });
+
     it("should subscribe 'userUpdated' after 'updateProfile' mutation", async () => {
       let subscriptionValue;
       const variables = {

--- a/server/tests/setup/queries/Channel.ts
+++ b/server/tests/setup/queries/Channel.ts
@@ -88,3 +88,11 @@ export const kickFromChannel = /* GraphQL */`
     }
   }
 `;
+
+export const findOrCreatePrivateChannel = /* GraphQL */`
+  mutation findOrCreatePrivateChannel($peerUserId: String!) {
+    findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+      id
+    }
+  }
+`;

--- a/server/tests/setup/queries/User.ts
+++ b/server/tests/setup/queries/User.ts
@@ -80,6 +80,12 @@ export const meQuery = /* GraphQL */`
       id
       email
       name
+      friends {
+        id
+      }
+      channels {
+        id
+      }
     }
   }
 `;


### PR DESCRIPTION
## Specify project
server

## Description

As we've discussed in today's sync, I've added `channels` field resolver in `User` model.
Then we can get `channels` from the `me` query.

Changed `findOrCreatePrivateChannelId` to `findOrCreatePrivateChannel` since we need more information to be handled in client.

- We have additional todo here to guard our field resolver. There is a [authorize plugin](https://nexusjs.org/components-standalone/schema/plugins/field-authorize) in nexus.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
