### PR TITLE
Exclude web platform from expo-notifications

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,4 @@ firebase-debug*.*
 .firebase
 
 .idea
+.gitmessage.txt

--- a/client/src/utils/noti.ts
+++ b/client/src/utils/noti.ts
@@ -22,7 +22,9 @@ export const registerForPushNotificationsAsync = async (): Promise<string | unde
       return;
     }
 
-    token = (await Notifications.getExpoPushTokenAsync()).data;
+    if (Platform.OS !== 'web') {
+      token = (await Notifications.getExpoPushTokenAsync()).data;
+    }
   } else {
     showAlertForError(getString('MUST_USE_PHYSICAL_DEVICE'));
   }


### PR DESCRIPTION
## Specify project
Client

## Description
When running the application in a web environment, the following error occurred after login.
**_"Unhandled Rejection (Error): You must provide `notification.vapidPublicKey` in `app.json` to use push notifications on web."_**

According to the [site](https://docs.expo.io/versions/v38.0.0/sdk/notifications/), the web is pending on compatible push notification platforms. In other words, an error occurs because push notification on the web is not currently supported.

Changed to not return token through getExpoPushTokenAsync() when running on web.

## Tests

I added the following tests:
* After changing the source code, I tested about push-notification on the [site](https://snack.expo.io/tPniI_tm1) and confirmed that push worked properly on a device other than web.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
