### PR TITLE
Integrate findOrCreatePrivateChannel and reveal user name as a title

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -1,3 +1,9 @@
+"""Exposes a URL that specifies the behaviour of this scalar."""
+directive @specifiedBy(
+  """The URL that specifies the behaviour of this scalar."""
+  url: String!
+) on SCALAR
+
 scalar AlertMode
 
 scalar Auth
@@ -164,6 +170,9 @@ type Mutation {
   """
   createChannel(channel: ChannelCreateInput, message: MessageCreateInput): Channel!
 
+  """Find or create channel associated to peer user id."""
+  findOrCreatePrivateChannel(peerUserId: String!): Channel!
+
   """
   User leaves [public] channel.
     Users cannot leave the [private] channel
@@ -300,6 +309,7 @@ type User {
   updatedAt: DateTime
   deletedAt: DateTime
   notifications: [Notification!]
+  channels: [Channel!]
   friends: [User!]
 }
 

--- a/client/src/__generated__/MainStackNavigatorFindOrCreatePrivateChannelMutation.graphql.ts
+++ b/client/src/__generated__/MainStackNavigatorFindOrCreatePrivateChannelMutation.graphql.ts
@@ -1,0 +1,101 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type MainStackNavigatorFindOrCreatePrivateChannelMutationVariables = {
+    peerUserId: string;
+};
+export type MainStackNavigatorFindOrCreatePrivateChannelMutationResponse = {
+    readonly findOrCreatePrivateChannel: {
+        readonly id: string;
+        readonly name: string | null;
+    };
+};
+export type MainStackNavigatorFindOrCreatePrivateChannelMutation = {
+    readonly response: MainStackNavigatorFindOrCreatePrivateChannelMutationResponse;
+    readonly variables: MainStackNavigatorFindOrCreatePrivateChannelMutationVariables;
+};
+
+
+
+/*
+mutation MainStackNavigatorFindOrCreatePrivateChannelMutation(
+  $peerUserId: String!
+) {
+  findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+    id
+    name
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "peerUserId"
+        } as any)
+    ], v1 = [
+        ({
+            "alias": null,
+            "args": [
+                {
+                    "kind": "Variable",
+                    "name": "peerUserId",
+                    "variableName": "peerUserId"
+                }
+            ],
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "findOrCreatePrivateChannel",
+            "plural": false,
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                }
+            ],
+            "storageKey": null
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "MainStackNavigatorFindOrCreatePrivateChannelMutation",
+            "selections": (v1 /*: any*/),
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "MainStackNavigatorFindOrCreatePrivateChannelMutation",
+            "selections": (v1 /*: any*/)
+        },
+        "params": {
+            "cacheID": "ecff917854f09eed34602ddf2f794f8b",
+            "id": null,
+            "metadata": {},
+            "name": "MainStackNavigatorFindOrCreatePrivateChannelMutation",
+            "operationKind": "mutation",
+            "text": "mutation MainStackNavigatorFindOrCreatePrivateChannelMutation(\n  $peerUserId: String!\n) {\n  findOrCreatePrivateChannel(peerUserId: $peerUserId) {\n    id\n    name\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = '606f28da88de79b9fc7bd61e0a1f26dc';
+export default node;

--- a/client/src/components/screen/Message.tsx
+++ b/client/src/components/screen/Message.tsx
@@ -1,6 +1,12 @@
-import { Image, Platform, TouchableOpacity, View } from 'react-native';
+import { Image, Platform, Text, TouchableOpacity, View } from 'react-native';
+import {
+  MainStackNavigationProps,
+  MainStackParamList,
+} from '../navigation/MainStackNavigator';
+import { Message, User } from '../../types/graphql';
 import { MessageProps, MessageType } from '../../types';
-import React, { useState } from 'react';
+import React, { FC, ReactElement, useState } from 'react';
+import { RouteProp, useNavigation } from '@react-navigation/core';
 import {
   launchCameraAsync,
   launchImageLibraryAsync,
@@ -12,7 +18,6 @@ import EmptyListItem from '../shared/EmptyListItem';
 import GiftedChat from '../shared/GiftedChat';
 import { IC_SMILE } from '../../utils/Icons';
 import { Ionicons } from '@expo/vector-icons';
-import { MainStackNavigationProps } from '../navigation/MainStackNavigator';
 import MessageListItem from '../shared/MessageListItem';
 import { getString } from '../../../STRINGS';
 import { isIPhoneX } from '../../utils/Styles';
@@ -29,10 +34,32 @@ const Container = styled.SafeAreaView`
 
 interface Props {
   navigation: MainStackNavigationProps<'Message'>;
+  route: RouteProp<MainStackParamList, 'Message'>;
 }
 
-function Message(): React.ReactElement {
+const MessageScreen: FC<Props> = (props) => {
   const { theme } = useThemeContext();
+  const { route: { params: { user, channel } } } = props;
+  const navigation = useNavigation();
+
+  navigation.setOptions({
+    headerTitle: (): ReactElement => {
+      let title = channel.name;
+
+      // Note that if the user exists, this is direct message which title should appear as user name or nickname
+      if (user) {
+        title = user.nickname || user.name || '';
+      }
+
+      return <Text style={{
+        color: 'white',
+        fontSize: 18,
+        fontWeight: '500',
+      }}>{title}</Text>;
+    },
+  });
+
+  // Note that if the user exists, this is direct message which title should appear as user name or nickname
 
   const [isSending, setIsSending] = useState<boolean>(false);
   const [textToSend, setTextToSend] = useState<string>('');
@@ -225,6 +252,6 @@ function Message(): React.ReactElement {
       />
     </Container>
   );
-}
+};
 
-export default Message;
+export default MessageScreen;

--- a/client/src/components/screen/SignIn.tsx
+++ b/client/src/components/screen/SignIn.tsx
@@ -225,7 +225,7 @@ function SignIn(props: Props): ReactElement {
         setUser(user);
       },
 
-      onError: (error: any): void => {
+      onError: (error: Error): void => {
         setErrorPassword(error.message);
         setErrorPassword(getString('PASSWORD_INCORRECT'));
       },

--- a/client/src/components/screen/__tests__/Message.test.tsx
+++ b/client/src/components/screen/__tests__/Message.test.tsx
@@ -12,7 +12,10 @@ import {
 } from '@testing-library/react-native';
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
+import { Channel } from '../../../types/graphql';
 import Message from '../Message';
+import { MockPayloadGenerator } from 'relay-test-utils';
+import { environment } from '../../../providers';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let props: any;
@@ -31,11 +34,33 @@ describe('[Message] rendering test', () => {
   jest.useFakeTimers();
 
   beforeEach(() => {
-    props = createTestProps();
+    props = createTestProps({
+      route: {
+        params: {
+          user: {
+            name: '',
+          },
+          channel: {
+            id: '',
+            name: '',
+          },
+        },
+      },
+    });
     component = createTestElement(<Message {...props} />);
+    environment.mockClear();
   });
 
   it('renders as expected', () => {
+    environment.mock.queueOperationResolver((operation) => {
+      return MockPayloadGenerator.generate(operation, {
+        Channel: (_, generateId): Partial<Channel> => ({
+          id: `channel-${generateId()}`,
+          name: 'John Doe',
+        }),
+      });
+    });
+
     const { baseElement } = render(component);
     expect(baseElement).toBeTruthy();
     expect(baseElement).toMatchSnapshot();

--- a/client/src/components/shared/ProfileModal.tsx
+++ b/client/src/components/shared/ProfileModal.tsx
@@ -3,6 +3,7 @@ import { TouchableOpacity, View, ViewStyle } from 'react-native';
 
 import { IC_NO_IMAGE } from '../../utils/Icons';
 import { Ionicons } from '@expo/vector-icons';
+import { LoadingIndicator } from 'dooboo-ui';
 import Modal from 'react-native-modalbox';
 import { User } from '../../types/graphql';
 import { getString } from '../../../STRINGS';
@@ -73,6 +74,7 @@ const StyledTextFriendAlreadyAdded = styled.Text`
 interface Props {
   testID?: string;
   ref?: React.MutableRefObject<Modal | null>;
+  isChatLoading?: boolean;
   onChatPressed?: () => void;
   onAddFriend?: () => void;
   onDeleteFriend?: () => void;
@@ -118,6 +120,7 @@ const Shared = forwardRef<Ref, Props>((props, ref) => {
   const {
     testID,
     onChatPressed,
+    isChatLoading,
     onAddFriend,
     onDeleteFriend,
   } = props;
@@ -161,7 +164,7 @@ const Shared = forwardRef<Ref, Props>((props, ref) => {
   };
 
   const addFriend = async (): Promise<void> => {
-    if (onAddFriend) { onAddFriend(); }
+    onAddFriend?.();
 
     if (modal) {
       modal.close();
@@ -182,7 +185,7 @@ const Shared = forwardRef<Ref, Props>((props, ref) => {
   };
 
   const deleteFriend = async (): Promise<void> => {
-    if (props.onDeleteFriend) { props.onDeleteFriend(); }
+    onDeleteFriend?.();
 
     if (modal) {
       modal.close();
@@ -293,14 +296,18 @@ const Shared = forwardRef<Ref, Props>((props, ref) => {
           <TouchableOpacity
             testID="btn-chat"
             activeOpacity={0.5}
-            onPress={props.onChatPressed}
+            onPress={onChatPressed}
             style={styles.viewBtn}
           >
-            <View style={styles.viewBtn}>
-              <StyledText style={{
-                color: modalBtnPrimaryFont,
-              }}>{getString('CHAT')}</StyledText>
-            </View>
+            {
+              isChatLoading
+                ? <LoadingIndicator size="small"/>
+                : <View style={styles.viewBtn}>
+                  <StyledText style={{
+                    color: modalBtnPrimaryFont,
+                  }}>{getString('CHAT')}</StyledText>
+                </View>
+            }
           </TouchableOpacity>
         </StyledViewBtns>
       </View>

--- a/client/src/types/graphql.ts
+++ b/client/src/types/graphql.ts
@@ -24,6 +24,8 @@ export type Scalars = {
   Upload: any;
 };
 
+
+
 export type AuthPayload = {
   __typename?: 'AuthPayload';
   token: Scalars['String'];
@@ -52,6 +54,7 @@ export type Channel = {
   memberships?: Maybe<Array<Membership>>;
 };
 
+
 export type ChannelMessagesArgs = {
   first?: Maybe<Scalars['Int']>;
   after?: Maybe<Scalars['String']>;
@@ -65,6 +68,9 @@ export type ChannelCreateInput = {
   userIds?: Maybe<Array<Scalars['String']>>;
 };
 
+
+
+
 export type Friend = {
   __typename?: 'Friend';
   createdAt?: Maybe<Scalars['DateTime']>;
@@ -73,6 +79,7 @@ export type Friend = {
   user?: Maybe<User>;
   friend?: Maybe<User>;
 };
+
 
 export type Membership = {
   __typename?: 'Membership';
@@ -84,6 +91,7 @@ export type Membership = {
   user?: Maybe<User>;
   channel?: Maybe<Channel>;
 };
+
 
 export type Message = {
   __typename?: 'Message';
@@ -124,6 +132,7 @@ export type MessageEdge = {
   node: Message;
 };
 
+
 export type Mutation = {
   __typename?: 'Mutation';
   signUp: User;
@@ -149,12 +158,14 @@ export type Mutation = {
    *   The public channel is something like an open chat while
    *   private channel is all kinds of direct messages.
    *   The [Membership] of private channel will be identical to all users which is (member).
-   *
+   *   
    *   <Optional> The channel can be created with message of [MessageType].
    *   Please becareful when creating message and provide proper [MessageType].
    *   This query will return [Channel] with [Membership] without [Message] that has just created.
    */
   createChannel: Channel;
+  /** Find or create channel associated to peer user id. */
+  findOrCreatePrivateChannel: Channel;
   /**
    * User leaves [public] channel.
    *   Users cannot leave the [private] channel
@@ -171,43 +182,53 @@ export type Mutation = {
   deleteMessage?: Maybe<Message>;
 };
 
+
 export type MutationSignUpArgs = {
   user?: Maybe<UserCreateInput>;
 };
+
 
 export type MutationSignInEmailArgs = {
   email: Scalars['String'];
   password: Scalars['String'];
 };
 
+
 export type MutationSignInWithFacebookArgs = {
   accessToken: Scalars['String'];
 };
+
 
 export type MutationSignInWithAppleArgs = {
   accessToken: Scalars['String'];
 };
 
+
 export type MutationSignInWithGoogleArgs = {
   accessToken: Scalars['String'];
 };
+
 
 export type MutationSendVerificationArgs = {
   email: Scalars['String'];
 };
 
+
 export type MutationUpdateProfileArgs = {
   user?: Maybe<UserUpdateInput>;
 };
+
 
 export type MutationFindPasswordArgs = {
   email: Scalars['String'];
 };
 
+
 export type MutationChangeEmailPasswordArgs = {
   password: Scalars['String'];
   newPassword: Scalars['String'];
 };
+
 
 export type MutationCreateNotificationArgs = {
   token: Scalars['String'];
@@ -215,46 +236,61 @@ export type MutationCreateNotificationArgs = {
   os?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationDeleteNotificationArgs = {
   token: Scalars['String'];
 };
+
 
 export type MutationSingleUploadArgs = {
   file?: Maybe<Scalars['Upload']>;
   dir?: Maybe<Scalars['String']>;
 };
 
+
 export type MutationAddFriendArgs = {
   friendId: Scalars['String'];
 };
 
+
 export type MutationDeleteFriendArgs = {
   friendId: Scalars['String'];
 };
+
 
 export type MutationCreateChannelArgs = {
   channel?: Maybe<ChannelCreateInput>;
   message?: Maybe<MessageCreateInput>;
 };
 
+
+export type MutationFindOrCreatePrivateChannelArgs = {
+  peerUserId: Scalars['String'];
+};
+
+
 export type MutationLeaveChannelArgs = {
   channelId: Scalars['String'];
 };
+
 
 export type MutationInviteUsersToChannelArgs = {
   channelId: Scalars['String'];
   userIds: Array<Scalars['String']>;
 };
 
+
 export type MutationKickUsersFromChannelArgs = {
   channelId: Scalars['String'];
   userIds: Array<Scalars['String']>;
 };
 
+
 export type MutationCreateMessageArgs = {
   channelId: Scalars['String'];
   message: MessageCreateInput;
 };
+
 
 export type MutationDeleteMessageArgs = {
   id: Scalars['String'];
@@ -301,6 +337,7 @@ export type Query = {
   myChannels?: Maybe<Array<Channel>>;
 };
 
+
 export type QueryUsersArgs = {
   searchText?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Int']>;
@@ -309,9 +346,11 @@ export type QueryUsersArgs = {
   before?: Maybe<Scalars['String']>;
 };
 
+
 export type QueryNotificationsArgs = {
   userId?: Maybe<Scalars['String']>;
 };
+
 
 export type QueryChannelArgs = {
   channelId?: Maybe<Scalars['String']>;
@@ -342,13 +381,16 @@ export type Subscription = {
   userUpdated: User;
 };
 
+
 export type SubscriptionUserSignedInArgs = {
   userId: Scalars['String'];
 };
 
+
 export type SubscriptionUserUpdatedArgs = {
   userId: Scalars['String'];
 };
+
 
 export type User = {
   __typename?: 'User';
@@ -370,6 +412,7 @@ export type User = {
   updatedAt?: Maybe<Scalars['DateTime']>;
   deletedAt?: Maybe<Scalars['DateTime']>;
   notifications?: Maybe<Array<Notification>>;
+  channels?: Maybe<Array<Channel>>;
   friends?: Maybe<Array<User>>;
 };
 

--- a/client/test/jestSetup.ts
+++ b/client/test/jestSetup.ts
@@ -7,3 +7,13 @@ jest.mock('@react-native-community/async-storage', () => mockAsyncStorage);
 const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
 customGlobal.fetch = require('jest-fetch-mock');
 customGlobal.fetchMock = customGlobal.fetch;
+
+jest.mock('@react-navigation/core', () => {
+  return {
+    ...jest.requireActual('@react-navigation/core'),
+    useNavigation: () => ({
+      navigate: jest.fn(),
+      setOptions: jest.fn(),
+    }),
+  };
+});


### PR DESCRIPTION
## Specify project
client

## Description

Followed by the work in [commit](https://github.com/dooboolab/hackatalk/commit/8ffebbc061fd7de7f55b79f9579c4b666b84bcf3), integrate `findOrCreatePrivateChannel` in `MainStackNavigator`. We call this resolver everytime we want to start a new direct message with the user.

Additional information in [start-direct-messaging](https://website.hackatalk.dev/docs/client/start-direct-messaging).

## Tests

Mocked `@react-navigation/core` to handle `useNavigation` hook in `Message` screen.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
