### PR TITLE
Change channels and friends field resolver to connection

### DIFF
--- a/.github/workflows/deploy-web-app.yml
+++ b/.github/workflows/deploy-web-app.yml
@@ -34,9 +34,9 @@ jobs:
 
     - name: Deploy to Firebase
       uses: w9jds/firebase-action@master
-      PROJECT_PATH: ./client
       with:
         args: deploy --only hosting
       env:
         FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        PROJECT_PATH: ./client
  

--- a/client/src/components/screen/__tests__/FindPw.test.tsx
+++ b/client/src/components/screen/__tests__/FindPw.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   render,
   wait,
+  waitForElement,
 } from '@testing-library/react-native';
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
@@ -68,8 +69,7 @@ describe('[FindPw] interaction', () => {
   });
 
   it('should invoke changeText event handler when email changed', async () => {
-    const textInput = testingLib.getByTestId('input-email');
-    await wait(() => expect(textInput).toBeTruthy());
+    const textInput = await waitForElement(() => testingLib.getByTestId('input-email'));
 
     act(() => {
       fireEvent.changeText(textInput, 'email@email.com');
@@ -88,8 +88,7 @@ describe('[FindPw] interaction', () => {
     });
 
     it('should show error text when the email is not validated', async () => {
-      const textInput = testingLib.getByTestId('input-email');
-      await wait(() => expect(textInput).toBeTruthy());
+      const textInput = await waitForElement(() => testingLib.getByTestId('input-email'));
 
       act(() => {
         fireEvent.changeText(textInput, 'example');

--- a/server/tests/setup/queries/User.ts
+++ b/server/tests/setup/queries/User.ts
@@ -80,11 +80,19 @@ export const meQuery = /* GraphQL */`
       id
       email
       name
-      friends {
-        id
+      friends(first: 10) {
+        edges {
+          node {
+            id
+          }
+        }
       }
-      channels {
-        id
+      channels(first: 10) {
+        edges {
+          node {
+            id
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Specify project
server

## Description

Change `channels` and `friends` list resolvers into `connection` since this should be fetched as a relay cursor pagination in `HackaTalk` mobile.

- Also fixed firebase webapp deploy workflow to run on sub dir which is `client`.

## Tests

- Fixed `meQuery` to connection that was used on tests.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
