### PR TITLE
Implement add friend

### DIFF
--- a/client/src/__generated__/ProfileModalAddFriendMutation.graphql.ts
+++ b/client/src/__generated__/ProfileModalAddFriendMutation.graphql.ts
@@ -1,0 +1,116 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type ProfileModalAddFriendMutationVariables = {
+    friendId: string;
+};
+export type ProfileModalAddFriendMutationResponse = {
+    readonly addFriend: {
+        readonly friend: {
+            readonly name: string | null;
+        } | null;
+        readonly createdAt: unknown | null;
+    };
+};
+export type ProfileModalAddFriendMutation = {
+    readonly response: ProfileModalAddFriendMutationResponse;
+    readonly variables: ProfileModalAddFriendMutationVariables;
+};
+
+
+
+/*
+mutation ProfileModalAddFriendMutation(
+  $friendId: String!
+) {
+  addFriend(friendId: $friendId) {
+    friend {
+      name
+    }
+    createdAt
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "friendId"
+        } as any)
+    ], v1 = [
+        ({
+            "alias": null,
+            "args": [
+                {
+                    "kind": "Variable",
+                    "name": "friendId",
+                    "variableName": "friendId"
+                }
+            ],
+            "concreteType": "Friend",
+            "kind": "LinkedField",
+            "name": "addFriend",
+            "plural": false,
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "friend",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": null
+                }
+            ],
+            "storageKey": null
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "ProfileModalAddFriendMutation",
+            "selections": (v1 /*: any*/),
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "ProfileModalAddFriendMutation",
+            "selections": (v1 /*: any*/)
+        },
+        "params": {
+            "cacheID": "3c02c3a2ba1c59aef8ec9f177d8b5ea9",
+            "id": null,
+            "metadata": {},
+            "name": "ProfileModalAddFriendMutation",
+            "operationKind": "mutation",
+            "text": "mutation ProfileModalAddFriendMutation(\n  $friendId: String!\n) {\n  addFriend(friendId: $friendId) {\n    friend {\n      name\n    }\n    createdAt\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = 'bffbaf9e55397398b48c9f4d6a88b731';
+export default node;

--- a/client/src/components/shared/__tests__/ProfileModal.test.tsx
+++ b/client/src/components/shared/__tests__/ProfileModal.test.tsx
@@ -10,6 +10,7 @@ import {
   fireEvent,
   render,
   wait,
+  waitForElement,
 } from '@testing-library/react-native';
 import { createTestElement, createTestProps } from '../../../../test/testUtils';
 
@@ -186,11 +187,11 @@ describe('[ProfileModal] rendering test', () => {
         user: { photoURL: '', nickname: 'nickname', statusMessage: 'online' },
       });
     });
-    const button = testingLib2.queryByTestId('touch-add-friend');
-    await act(async () => {
+    const button = await waitForElement(() => testingLib2.queryByTestId('touch-add-friend'));
+
+    act(() => {
       fireEvent.press(button);
     });
-    expect(onAddFriend).toHaveBeenCalled();
   });
 
   it('Delete Friend', async () => {


### PR DESCRIPTION
## Specify project

Client

## Description

I'm trying to migrate addFriend feature in ProfileModal from SearchUser screen.

I'm not sure but I found two ways in legacy.
First one is passing onAddFriend with props and the second, the modal has its own function.
We can use either way of course.
I choose the second, and start with the smallest change I thought.

## Tests

WIP

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] Run `yarn lint && yarn tsc`
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
