### PR TITLE
Implement online status tagging on photo

### DIFF
--- a/client/src/components/screen/Friend.tsx
+++ b/client/src/components/screen/Friend.tsx
@@ -80,6 +80,7 @@ export default function Screen(): ReactElement {
     return (
       <UserListItem
         testID={testID}
+        showStatus
         user={item.node}
         onPress={userListOnPressInlineFn}
       />

--- a/client/src/components/shared/UserListItem.tsx
+++ b/client/src/components/shared/UserListItem.tsx
@@ -14,6 +14,7 @@ interface Props {
   onPress?: () => void;
   onLongPress?: () => void;
   showCheckBox?: boolean;
+  showStatus?: boolean;
   checked?: boolean;
 }
 
@@ -30,6 +31,22 @@ const Wrapper = styled.View`
   align-items: center;
   justify-content: flex-start;
   padding: 0 20px;
+`;
+
+const ImageWrapper = styled.View`
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const StatusTag = styled.View`
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 12;
+  height: 12;
+  border-radius: 25px;
 `;
 
 const StyledImage = styled.Image`
@@ -59,11 +76,12 @@ const StyledRightText = styled.Text`
 
 function Shared({
   showCheckBox = false,
+  showStatus = false,
   checked = false,
   onPress,
   onLongPress,
   testID,
-  user: { photoURL = '', email, nickname, name, statusMessage },
+  user: { photoURL = '', email, nickname, name, statusMessage, isOnline },
 }: Props): React.ReactElement {
   const { theme } = useThemeContext();
 
@@ -81,20 +99,20 @@ function Shared({
         onLongPress={onLongPress}
       >
         <Wrapper>
-          {
-            photoURL && photoURLObj
-              ? <StyledImage source={photoURLObj} />
-              : <View
-                style={{
-                  width: 40,
-                  height: 40,
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <StyledImage source={IC_NO_IMAGE} />
-              </View>
-          }
+          <ImageWrapper>
+            <StyledImage
+              source={
+                photoURL && photoURLObj
+                  ? photoURLObj
+                  : IC_NO_IMAGE
+              }
+            />
+            {
+              showStatus
+                ? <StatusTag style={{ backgroundColor: isOnline ? '#00D4AB' : '#AFB4C3' }} />
+                : null
+            }
+          </ImageWrapper>
           <StyledText numberOfLines={1}>{name || nickname}</StyledText>
           {
             showCheckBox

--- a/client/src/components/shared/UserListItem.tsx
+++ b/client/src/components/shared/UserListItem.tsx
@@ -44,8 +44,8 @@ const StatusTag = styled.View`
   position: absolute;
   top: 0;
   right: 0;
-  width: 12;
-  height: 12;
+  width: 12px;
+  height: 12px;
   border-radius: 25px;
 `;
 

--- a/client/src/components/shared/__tests__/__snapshots__/UserListItem.test.tsx.snap
+++ b/client/src/components/shared/__tests__/__snapshots__/UserListItem.test.tsx.snap
@@ -52,12 +52,14 @@ exports[`[UserListItem] rendering test renders as expected 1`] = `
         >
           <View
             style={
-              Object {
-                "alignItems": "center",
-                "height": 40,
-                "justifyContent": "center",
-                "width": 40,
-              }
+              Array [
+                Object {
+                  "alignItems": "center",
+                  "height": 40,
+                  "justifyContent": "center",
+                  "width": 40,
+                },
+              ]
             }
           >
             <Image


### PR DESCRIPTION
## Specify project

Client

## Description

Design guide displays online status to the right of the UserListItem.
However, check-boxe and status message have already been placed.
So I suggest marking at the top right of the photo as usual

### Before & Default 

<img width="382" alt="default" src="https://user-images.githubusercontent.com/18386669/93171117-6fef5400-f763-11ea-8aee-50758df7086b.png">

### After

Ios / Android / Web

<p float="left">
  <img src="https://user-images.githubusercontent.com/18386669/93171206-97deb780-f763-11ea-8fb0-3905f12a5b64.png" width="200" />
  <img src="https://user-images.githubusercontent.com/18386669/93171224-9f9e5c00-f763-11ea-95ed-22a8475d0e35.png" width="200" /> 
  <img src="https://user-images.githubusercontent.com/18386669/93171449-16d3f000-f764-11ea-985e-fdfb68eab097.png" width="200" />
</p>


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
