### PR TITLE
Fix Import Issue of [expo-notifications]

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,3 +1,5 @@
+import * as Notifications from 'expo-notifications';
+
 import type {
   AppUserQuery,
   AppUserQueryResponse,
@@ -24,7 +26,6 @@ import Device from 'expo-device';
 import Icons from './utils/Icons';
 import { Image } from 'react-native';
 import { LoadingIndicator } from 'dooboo-ui';
-import Notifications from 'expo-notifications';
 import RootNavigator from './components/navigation/RootStackNavigator';
 import { User } from 'types/graphql';
 import { registerForPushNotificationsAsync } from './utils/noti';


### PR DESCRIPTION
## Specify project
Client

## Description
`expo-notifications` module do not have a default export.
Do a wildcard import for `expo-notifications`.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
