### PR TITLE
Translate [ChannelCreate] into relay pagination

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -74,6 +74,7 @@
     "react-native-reanimated": "~1.13.0",
     "react-native-redash": "^14.2.4",
     "react-native-safe-area-context": "3.1.4",
+    "react-native-scalable-image": "^1.0.0",
     "react-native-screens": "~2.10.1",
     "react-native-svg": "12.1.0",
     "react-native-tab-view": "^2.15.2",

--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -188,7 +188,7 @@ type Mutation {
   createChannel(channel: ChannelCreateInput, message: MessageCreateInput): Channel!
 
   """Find or create channel associated to peer user id."""
-  findOrCreatePrivateChannel(peerUserId: String!): Channel!
+  findOrCreatePrivateChannel(peerUserIds: [String]!): Channel!
 
   """
   User leaves [public] channel.

--- a/client/src/__generated__/ChannelCreateFindOrCreatePrivateChannelMutation.graphql.ts
+++ b/client/src/__generated__/ChannelCreateFindOrCreatePrivateChannelMutation.graphql.ts
@@ -1,0 +1,101 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+export type ChannelCreateFindOrCreatePrivateChannelMutationVariables = {
+    peerUserId: string;
+};
+export type ChannelCreateFindOrCreatePrivateChannelMutationResponse = {
+    readonly findOrCreatePrivateChannel: {
+        readonly id: string;
+        readonly name: string | null;
+    };
+};
+export type ChannelCreateFindOrCreatePrivateChannelMutation = {
+    readonly response: ChannelCreateFindOrCreatePrivateChannelMutationResponse;
+    readonly variables: ChannelCreateFindOrCreatePrivateChannelMutationVariables;
+};
+
+
+
+/*
+mutation ChannelCreateFindOrCreatePrivateChannelMutation(
+  $peerUserId: String!
+) {
+  findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+    id
+    name
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "peerUserId"
+        } as any)
+    ], v1 = [
+        ({
+            "alias": null,
+            "args": [
+                {
+                    "kind": "Variable",
+                    "name": "peerUserId",
+                    "variableName": "peerUserId"
+                }
+            ],
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "findOrCreatePrivateChannel",
+            "plural": false,
+            "selections": [
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                }
+            ],
+            "storageKey": null
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "ChannelCreateFindOrCreatePrivateChannelMutation",
+            "selections": (v1 /*: any*/),
+            "type": "Mutation",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "ChannelCreateFindOrCreatePrivateChannelMutation",
+            "selections": (v1 /*: any*/)
+        },
+        "params": {
+            "cacheID": "1d0a8cc48aa29922537b5cd4920e1201",
+            "id": null,
+            "metadata": {},
+            "name": "ChannelCreateFindOrCreatePrivateChannelMutation",
+            "operationKind": "mutation",
+            "text": "mutation ChannelCreateFindOrCreatePrivateChannelMutation(\n  $peerUserId: String!\n) {\n  findOrCreatePrivateChannel(peerUserId: $peerUserId) {\n    id\n    name\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = '0c05e3fecb2f638e6839d1a9d5bdab30';
+export default node;

--- a/client/src/__generated__/ChannelCreateFindOrCreatePrivateChannelMutation.graphql.ts
+++ b/client/src/__generated__/ChannelCreateFindOrCreatePrivateChannelMutation.graphql.ts
@@ -4,12 +4,13 @@
 
 import { ConcreteRequest } from "relay-runtime";
 export type ChannelCreateFindOrCreatePrivateChannelMutationVariables = {
-    peerUserId: string;
+    peerUserIds: Array<string | null>;
 };
 export type ChannelCreateFindOrCreatePrivateChannelMutationResponse = {
     readonly findOrCreatePrivateChannel: {
         readonly id: string;
         readonly name: string | null;
+        readonly channelType: unknown;
     };
 };
 export type ChannelCreateFindOrCreatePrivateChannelMutation = {
@@ -21,11 +22,12 @@ export type ChannelCreateFindOrCreatePrivateChannelMutation = {
 
 /*
 mutation ChannelCreateFindOrCreatePrivateChannelMutation(
-  $peerUserId: String!
+  $peerUserIds: [String]!
 ) {
-  findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+  findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {
     id
     name
+    channelType
   }
 }
 */
@@ -35,7 +37,7 @@ const node: ConcreteRequest = (function () {
         ({
             "defaultValue": null,
             "kind": "LocalArgument",
-            "name": "peerUserId"
+            "name": "peerUserIds"
         } as any)
     ], v1 = [
         ({
@@ -43,8 +45,8 @@ const node: ConcreteRequest = (function () {
             "args": [
                 {
                     "kind": "Variable",
-                    "name": "peerUserId",
-                    "variableName": "peerUserId"
+                    "name": "peerUserIds",
+                    "variableName": "peerUserIds"
                 }
             ],
             "concreteType": "Channel",
@@ -64,6 +66,13 @@ const node: ConcreteRequest = (function () {
                     "args": null,
                     "kind": "ScalarField",
                     "name": "name",
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "channelType",
                     "storageKey": null
                 }
             ],
@@ -88,14 +97,14 @@ const node: ConcreteRequest = (function () {
             "selections": (v1 /*: any*/)
         },
         "params": {
-            "cacheID": "1d0a8cc48aa29922537b5cd4920e1201",
+            "cacheID": "7775e86d79b319dfd656de8e6e9e9ac4",
             "id": null,
             "metadata": {},
             "name": "ChannelCreateFindOrCreatePrivateChannelMutation",
             "operationKind": "mutation",
-            "text": "mutation ChannelCreateFindOrCreatePrivateChannelMutation(\n  $peerUserId: String!\n) {\n  findOrCreatePrivateChannel(peerUserId: $peerUserId) {\n    id\n    name\n  }\n}\n"
+            "text": "mutation ChannelCreateFindOrCreatePrivateChannelMutation(\n  $peerUserIds: [String]!\n) {\n  findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {\n    id\n    name\n    channelType\n  }\n}\n"
         }
     } as any;
 })();
-(node as any).hash = '0c05e3fecb2f638e6839d1a9d5bdab30';
+(node as any).hash = '7c01e2d7590e8ddad00c80134f31ec8d';
 export default node;

--- a/client/src/__generated__/ChannelCreateFriendsPaginationQuery.graphql.ts
+++ b/client/src/__generated__/ChannelCreateFriendsPaginationQuery.graphql.ts
@@ -1,0 +1,327 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ChannelCreateFriendsPaginationQueryVariables = {
+    after?: string | null;
+    first: number;
+    searchText?: string | null;
+};
+export type ChannelCreateFriendsPaginationQueryResponse = {
+    readonly " $fragmentRefs": FragmentRefs<"ChannelCreate_friends">;
+};
+export type ChannelCreateFriendsPaginationQuery = {
+    readonly response: ChannelCreateFriendsPaginationQueryResponse;
+    readonly variables: ChannelCreateFriendsPaginationQueryVariables;
+};
+
+
+
+/*
+query ChannelCreateFriendsPaginationQuery(
+  $after: String
+  $first: Int!
+  $searchText: String
+) {
+  ...ChannelCreate_friends_2yyznZ
+}
+
+fragment ChannelCreate_friends_2yyznZ on Query {
+  friends(first: $first, after: $after, searchText: $searchText) {
+    edges {
+      cursor
+      node {
+        id
+        email
+        name
+        nickname
+        thumbURL
+        photoURL
+        birthday
+        gender
+        phone
+        statusMessage
+        verified
+        lastSignedIn
+        isOnline
+        createdAt
+        updatedAt
+        deletedAt
+        __typename
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = [
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "after"
+        } as any),
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "first"
+        } as any),
+        ({
+            "defaultValue": null,
+            "kind": "LocalArgument",
+            "name": "searchText"
+        } as any)
+    ], v1 = [
+        ({
+            "kind": "Variable",
+            "name": "after",
+            "variableName": "after"
+        } as any),
+        ({
+            "kind": "Variable",
+            "name": "first",
+            "variableName": "first"
+        } as any),
+        ({
+            "kind": "Variable",
+            "name": "searchText",
+            "variableName": "searchText"
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "ChannelCreateFriendsPaginationQuery",
+            "selections": [
+                {
+                    "args": (v1 /*: any*/),
+                    "kind": "FragmentSpread",
+                    "name": "ChannelCreate_friends"
+                }
+            ],
+            "type": "Query",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": (v0 /*: any*/),
+            "kind": "Operation",
+            "name": "ChannelCreateFriendsPaginationQuery",
+            "selections": [
+                {
+                    "alias": null,
+                    "args": (v1 /*: any*/),
+                    "concreteType": "UserConnection",
+                    "kind": "LinkedField",
+                    "name": "friends",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "UserEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "cursor",
+                                    "storageKey": null
+                                },
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "User",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "id",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "email",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "name",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "nickname",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "thumbURL",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "photoURL",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "birthday",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "gender",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "phone",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "statusMessage",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "verified",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "lastSignedIn",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnline",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "createdAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "updatedAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "deletedAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "__typename",
+                                            "storageKey": null
+                                        }
+                                    ],
+                                    "storageKey": null
+                                }
+                            ],
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PageInfo",
+                            "kind": "LinkedField",
+                            "name": "pageInfo",
+                            "plural": false,
+                            "selections": [
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "hasNextPage",
+                                    "storageKey": null
+                                },
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "endCursor",
+                                    "storageKey": null
+                                }
+                            ],
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": (v1 /*: any*/),
+                    "filters": [
+                        "searchText"
+                    ],
+                    "handle": "connection",
+                    "key": "ChannelCreate_friends",
+                    "kind": "LinkedHandle",
+                    "name": "friends"
+                }
+            ]
+        },
+        "params": {
+            "cacheID": "67dd120ea3e06232d4cae4742c98db3d",
+            "id": null,
+            "metadata": {},
+            "name": "ChannelCreateFriendsPaginationQuery",
+            "operationKind": "query",
+            "text": "query ChannelCreateFriendsPaginationQuery(\n  $after: String\n  $first: Int!\n  $searchText: String\n) {\n  ...ChannelCreate_friends_2yyznZ\n}\n\nfragment ChannelCreate_friends_2yyznZ on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        nickname\n        thumbURL\n        photoURL\n        birthday\n        gender\n        phone\n        statusMessage\n        verified\n        lastSignedIn\n        isOnline\n        createdAt\n        updatedAt\n        deletedAt\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = 'ea45366d850233ea9a81613dc0c54992';
+export default node;

--- a/client/src/__generated__/ChannelCreateFriendsQuery.graphql.ts
+++ b/client/src/__generated__/ChannelCreateFriendsQuery.graphql.ts
@@ -1,0 +1,331 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ChannelCreateFriendsQueryVariables = {
+    first: number;
+    after?: string | null;
+    searchText?: string | null;
+};
+export type ChannelCreateFriendsQueryResponse = {
+    readonly " $fragmentRefs": FragmentRefs<"ChannelCreate_friends">;
+};
+export type ChannelCreateFriendsQuery = {
+    readonly response: ChannelCreateFriendsQueryResponse;
+    readonly variables: ChannelCreateFriendsQueryVariables;
+};
+
+
+
+/*
+query ChannelCreateFriendsQuery(
+  $first: Int!
+  $after: String
+  $searchText: String
+) {
+  ...ChannelCreate_friends_2yyznZ
+}
+
+fragment ChannelCreate_friends_2yyznZ on Query {
+  friends(first: $first, after: $after, searchText: $searchText) {
+    edges {
+      cursor
+      node {
+        id
+        email
+        name
+        nickname
+        thumbURL
+        photoURL
+        birthday
+        gender
+        phone
+        statusMessage
+        verified
+        lastSignedIn
+        isOnline
+        createdAt
+        updatedAt
+        deletedAt
+        __typename
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+*/
+
+const node: ConcreteRequest = (function () {
+    var v0 = ({
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "after"
+    } as any), v1 = ({
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "first"
+    } as any), v2 = ({
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "searchText"
+    } as any), v3 = [
+        ({
+            "kind": "Variable",
+            "name": "after",
+            "variableName": "after"
+        } as any),
+        ({
+            "kind": "Variable",
+            "name": "first",
+            "variableName": "first"
+        } as any),
+        ({
+            "kind": "Variable",
+            "name": "searchText",
+            "variableName": "searchText"
+        } as any)
+    ];
+    return {
+        "fragment": {
+            "argumentDefinitions": [
+                (v0 /*: any*/),
+                (v1 /*: any*/),
+                (v2 /*: any*/)
+            ],
+            "kind": "Fragment",
+            "metadata": null,
+            "name": "ChannelCreateFriendsQuery",
+            "selections": [
+                {
+                    "args": (v3 /*: any*/),
+                    "kind": "FragmentSpread",
+                    "name": "ChannelCreate_friends"
+                }
+            ],
+            "type": "Query",
+            "abstractKey": null
+        },
+        "kind": "Request",
+        "operation": {
+            "argumentDefinitions": [
+                (v1 /*: any*/),
+                (v0 /*: any*/),
+                (v2 /*: any*/)
+            ],
+            "kind": "Operation",
+            "name": "ChannelCreateFriendsQuery",
+            "selections": [
+                {
+                    "alias": null,
+                    "args": (v3 /*: any*/),
+                    "concreteType": "UserConnection",
+                    "kind": "LinkedField",
+                    "name": "friends",
+                    "plural": false,
+                    "selections": [
+                        {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "UserEdge",
+                            "kind": "LinkedField",
+                            "name": "edges",
+                            "plural": true,
+                            "selections": [
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "cursor",
+                                    "storageKey": null
+                                },
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "User",
+                                    "kind": "LinkedField",
+                                    "name": "node",
+                                    "plural": false,
+                                    "selections": [
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "id",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "email",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "name",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "nickname",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "thumbURL",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "photoURL",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "birthday",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "gender",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "phone",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "statusMessage",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "verified",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "lastSignedIn",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "isOnline",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "createdAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "updatedAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "deletedAt",
+                                            "storageKey": null
+                                        },
+                                        {
+                                            "alias": null,
+                                            "args": null,
+                                            "kind": "ScalarField",
+                                            "name": "__typename",
+                                            "storageKey": null
+                                        }
+                                    ],
+                                    "storageKey": null
+                                }
+                            ],
+                            "storageKey": null
+                        },
+                        {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PageInfo",
+                            "kind": "LinkedField",
+                            "name": "pageInfo",
+                            "plural": false,
+                            "selections": [
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "hasNextPage",
+                                    "storageKey": null
+                                },
+                                {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "endCursor",
+                                    "storageKey": null
+                                }
+                            ],
+                            "storageKey": null
+                        }
+                    ],
+                    "storageKey": null
+                },
+                {
+                    "alias": null,
+                    "args": (v3 /*: any*/),
+                    "filters": [
+                        "searchText"
+                    ],
+                    "handle": "connection",
+                    "key": "ChannelCreate_friends",
+                    "kind": "LinkedHandle",
+                    "name": "friends"
+                }
+            ]
+        },
+        "params": {
+            "cacheID": "581f9f72960ad85ddb61d1387f1be5d1",
+            "id": null,
+            "metadata": {},
+            "name": "ChannelCreateFriendsQuery",
+            "operationKind": "query",
+            "text": "query ChannelCreateFriendsQuery(\n  $first: Int!\n  $after: String\n  $searchText: String\n) {\n  ...ChannelCreate_friends_2yyznZ\n}\n\nfragment ChannelCreate_friends_2yyznZ on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        nickname\n        thumbURL\n        photoURL\n        birthday\n        gender\n        phone\n        statusMessage\n        verified\n        lastSignedIn\n        isOnline\n        createdAt\n        updatedAt\n        deletedAt\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n"
+        }
+    } as any;
+})();
+(node as any).hash = 'bec5995afca6f8f4eb949783bd7445a5';
+export default node;

--- a/client/src/__generated__/ChannelCreate_friends.graphql.ts
+++ b/client/src/__generated__/ChannelCreate_friends.graphql.ts
@@ -1,0 +1,288 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type ChannelCreate_friends = {
+    readonly friends: {
+        readonly edges: ReadonlyArray<{
+            readonly cursor: string;
+            readonly node: {
+                readonly id: string;
+                readonly email: string | null;
+                readonly name: string | null;
+                readonly nickname: string | null;
+                readonly thumbURL: string | null;
+                readonly photoURL: string | null;
+                readonly birthday: unknown | null;
+                readonly gender: unknown | null;
+                readonly phone: string | null;
+                readonly statusMessage: string | null;
+                readonly verified: boolean | null;
+                readonly lastSignedIn: unknown | null;
+                readonly isOnline: boolean | null;
+                readonly createdAt: unknown | null;
+                readonly updatedAt: unknown | null;
+                readonly deletedAt: unknown | null;
+            };
+        } | null> | null;
+        readonly pageInfo: {
+            readonly hasNextPage: boolean;
+            readonly endCursor: string | null;
+        };
+    };
+    readonly " $refType": "ChannelCreate_friends";
+};
+export type ChannelCreate_friends$data = ChannelCreate_friends;
+export type ChannelCreate_friends$key = {
+    readonly " $data"?: ChannelCreate_friends$data;
+    readonly " $fragmentRefs": FragmentRefs<"ChannelCreate_friends">;
+};
+
+
+
+const node: ReaderFragment = (function () {
+    var v0 = [
+        "friends"
+    ];
+    return {
+        "argumentDefinitions": [
+            {
+                "defaultValue": null,
+                "kind": "LocalArgument",
+                "name": "after"
+            },
+            {
+                "defaultValue": null,
+                "kind": "LocalArgument",
+                "name": "first"
+            },
+            {
+                "defaultValue": null,
+                "kind": "LocalArgument",
+                "name": "searchText"
+            }
+        ],
+        "kind": "Fragment",
+        "metadata": {
+            "connection": [
+                {
+                    "count": "first",
+                    "cursor": "after",
+                    "direction": "forward",
+                    "path": (v0 /*: any*/)
+                }
+            ],
+            "refetch": {
+                "connection": {
+                    "forward": {
+                        "count": "first",
+                        "cursor": "after"
+                    },
+                    "backward": null,
+                    "path": (v0 /*: any*/)
+                },
+                "fragmentPathInResult": [],
+                "operation": require('./ChannelCreateFriendsPaginationQuery.graphql.ts')
+            }
+        },
+        "name": "ChannelCreate_friends",
+        "selections": [
+            {
+                "alias": "friends",
+                "args": [
+                    {
+                        "kind": "Variable",
+                        "name": "searchText",
+                        "variableName": "searchText"
+                    }
+                ],
+                "concreteType": "UserConnection",
+                "kind": "LinkedField",
+                "name": "__ChannelCreate_friends_connection",
+                "plural": false,
+                "selections": [
+                    {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "UserEdge",
+                        "kind": "LinkedField",
+                        "name": "edges",
+                        "plural": true,
+                        "selections": [
+                            {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cursor",
+                                "storageKey": null
+                            },
+                            {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "User",
+                                "kind": "LinkedField",
+                                "name": "node",
+                                "plural": false,
+                                "selections": [
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "id",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "email",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "name",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "nickname",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "thumbURL",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "photoURL",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "birthday",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "gender",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "phone",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "statusMessage",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "verified",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "lastSignedIn",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "isOnline",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "createdAt",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "updatedAt",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "deletedAt",
+                                        "storageKey": null
+                                    },
+                                    {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "__typename",
+                                        "storageKey": null
+                                    }
+                                ],
+                                "storageKey": null
+                            }
+                        ],
+                        "storageKey": null
+                    },
+                    {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PageInfo",
+                        "kind": "LinkedField",
+                        "name": "pageInfo",
+                        "plural": false,
+                        "selections": [
+                            {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "hasNextPage",
+                                "storageKey": null
+                            },
+                            {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "endCursor",
+                                "storageKey": null
+                            }
+                        ],
+                        "storageKey": null
+                    }
+                ],
+                "storageKey": null
+            }
+        ],
+        "type": "Query",
+        "abstractKey": null
+    } as any;
+})();
+(node as any).hash = 'ea45366d850233ea9a81613dc0c54992';
+export default node;

--- a/client/src/__generated__/ProfileModalFindOrCreatePrivateChannelMutation.graphql.ts
+++ b/client/src/__generated__/ProfileModalFindOrCreatePrivateChannelMutation.graphql.ts
@@ -4,7 +4,7 @@
 
 import { ConcreteRequest } from "relay-runtime";
 export type ProfileModalFindOrCreatePrivateChannelMutationVariables = {
-    peerUserId: string;
+    peerUserIds: Array<string | null>;
 };
 export type ProfileModalFindOrCreatePrivateChannelMutationResponse = {
     readonly findOrCreatePrivateChannel: {
@@ -21,9 +21,9 @@ export type ProfileModalFindOrCreatePrivateChannelMutation = {
 
 /*
 mutation ProfileModalFindOrCreatePrivateChannelMutation(
-  $peerUserId: String!
+  $peerUserIds: [String]!
 ) {
-  findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+  findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {
     id
     name
   }
@@ -35,7 +35,7 @@ const node: ConcreteRequest = (function () {
         ({
             "defaultValue": null,
             "kind": "LocalArgument",
-            "name": "peerUserId"
+            "name": "peerUserIds"
         } as any)
     ], v1 = [
         ({
@@ -43,8 +43,8 @@ const node: ConcreteRequest = (function () {
             "args": [
                 {
                     "kind": "Variable",
-                    "name": "peerUserId",
-                    "variableName": "peerUserId"
+                    "name": "peerUserIds",
+                    "variableName": "peerUserIds"
                 }
             ],
             "concreteType": "Channel",
@@ -88,14 +88,14 @@ const node: ConcreteRequest = (function () {
             "selections": (v1 /*: any*/)
         },
         "params": {
-            "cacheID": "bb3817a5b3188142225aeec376b02285",
+            "cacheID": "522ef9824dfeb93998a3042377af0f7a",
             "id": null,
             "metadata": {},
             "name": "ProfileModalFindOrCreatePrivateChannelMutation",
             "operationKind": "mutation",
-            "text": "mutation ProfileModalFindOrCreatePrivateChannelMutation(\n  $peerUserId: String!\n) {\n  findOrCreatePrivateChannel(peerUserId: $peerUserId) {\n    id\n    name\n  }\n}\n"
+            "text": "mutation ProfileModalFindOrCreatePrivateChannelMutation(\n  $peerUserIds: [String]!\n) {\n  findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {\n    id\n    name\n  }\n}\n"
         }
     } as any;
 })();
-(node as any).hash = '8f6f8c601dd5d032985f8f5107351824';
+(node as any).hash = '34a5a6c57027450dadb72178060e8651';
 export default node;

--- a/client/src/components/navigation/MainStackNavigator.tsx
+++ b/client/src/components/navigation/MainStackNavigator.tsx
@@ -36,7 +36,7 @@ export type MainStackParamList = {
   SearchUser: undefined;
   Message: {
     channel: Channel;
-    user?: User;
+    users?: User[];
   };
   Settings: undefined;
   ChangePw: undefined;

--- a/client/src/components/screen/Channel.tsx
+++ b/client/src/components/screen/Channel.tsx
@@ -195,7 +195,7 @@ const ChannelsFragment: FC<ChannelProps> = ({
         onPress={(): void => {
           navigation.navigate('Message', {
             channel: item.node,
-            users: [item.node?.memberships?.[0]?.user],
+            users: item.node?.memberships?.map((membership) => membership?.user),
           });
         }}
       />

--- a/client/src/components/screen/Channel.tsx
+++ b/client/src/components/screen/Channel.tsx
@@ -195,7 +195,7 @@ const ChannelsFragment: FC<ChannelProps> = ({
         onPress={(): void => {
           navigation.navigate('Message', {
             channel: item.node,
-            user: item.node?.memberships?.[0]?.user,
+            users: [item.node?.memberships?.[0]?.user],
           });
         }}
       />

--- a/client/src/components/screen/ChannelCreate.tsx
+++ b/client/src/components/screen/ChannelCreate.tsx
@@ -104,7 +104,9 @@ type FriendsFragmentProps = {
 };
 
 const FriendsFragment: FC<FriendsFragmentProps> = ({
+  scrollY,
   friend,
+  searchArgs,
 }) => {
   const {
     data,
@@ -251,7 +253,7 @@ const ContentContainer: FC<ContentProps> = ({
 }) => {
   const queryResponse = useLazyLoadQuery<ChannelCreateFriendsQuery>(
     friendsQuery,
-    { first: ITEM_CNT },
+    searchArgs,
     { fetchPolicy: 'store-or-network' },
   );
 

--- a/client/src/components/screen/ChannelCreate.tsx
+++ b/client/src/components/screen/ChannelCreate.tsx
@@ -27,7 +27,7 @@ import { ChannelCreateFriendsQuery } from '../../__generated__/ChannelCreateFrie
 import { ChannelCreate_friends$key } from '../../__generated__/ChannelCreate_friends.graphql';
 import ErroView from '../shared/ErrorView';
 import { LoadingIndicator } from 'dooboo-ui';
-import { RootStackNavigationProps } from '../navigation/RootStackNavigator';
+import { MainStackNavigationProps } from '../navigation/MainStackNavigator';
 import SearchTextInput from '../shared/SearchTextInput';
 import UserListItem from '../shared/UserListItem';
 import { getString } from '../../../STRINGS';
@@ -57,10 +57,11 @@ interface ChannelCreate extends User {
 }
 
 const findOrCreatePrivateChannel = graphql`
-  mutation ChannelCreateFindOrCreatePrivateChannelMutation($peerUserId: String!) {
-    findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+  mutation ChannelCreateFindOrCreatePrivateChannelMutation($peerUserIds: [String]!) {
+    findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {
       id
       name
+      channelType
     }
   }
 `;
@@ -306,7 +307,7 @@ const ContentContainer: FC<ContentProps> = ({
 };
 
 interface ChannelCreateProps {
-  navigation: RootStackNavigationProps<'default'>;
+  navigation: MainStackNavigationProps<'ChannelCreate'>;
 }
 
 const ChannelCreate: FC<ChannelCreateProps> = (props) => {
@@ -337,19 +338,19 @@ const ChannelCreate: FC<ChannelCreateProps> = (props) => {
   };
 
   const pressDone = (): void => {
+    const userIds = selectedUsers.map((v) => v.id);
+
     const mutationConfig = {
       variables: {
-        peerUserId: user.id,
+        peerUserIds: userIds,
       },
       onCompleted: (
         response: ChannelCreateFindOrCreatePrivateChannelMutationResponse,
       ): void => {
         const channel = response.findOrCreatePrivateChannel;
 
-        hideModal();
-
         navigation.navigate('Message', {
-          user,
+          users: selectedUsers,
           channel,
         });
       },

--- a/client/src/components/screen/ChannelCreate.tsx
+++ b/client/src/components/screen/ChannelCreate.tsx
@@ -1,4 +1,5 @@
 import {
+  Animated,
   FlatList,
   Image,
   ScrollView,
@@ -7,118 +8,37 @@ import {
   View,
 } from 'react-native';
 import {
+  ChannelCreateFriendsPaginationQuery,
+  ChannelCreateFriendsPaginationQueryVariables,
+} from '../../__generated__/ChannelCreateFriendsPaginationQuery.graphql';
+import {
   IC_CIRCLE_X,
   IC_NO_IMAGE,
 } from '../../utils/Icons';
-import React, { ReactElement, useState } from 'react';
+import React, { FC, ReactElement, Suspense, useMemo, useState } from 'react';
+import { User, UserEdge } from '../../types/graphql';
+import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay/hooks';
 
+import { ChannelCreateFriendsQuery } from '../../__generated__/ChannelCreateFriendsQuery.graphql';
+import { ChannelCreate_friends$key } from '../../__generated__/ChannelCreate_friends.graphql';
 import ErroView from '../shared/ErrorView';
+import { LoadingIndicator } from 'dooboo-ui';
 import { RootStackNavigationProps } from '../navigation/RootStackNavigator';
 import SearchTextInput from '../shared/SearchTextInput';
-import { User } from '../../types/graphql';
 import UserListItem from '../shared/UserListItem';
 import { getString } from '../../../STRINGS';
 import produce from 'immer';
 import styled from 'styled-components/native';
+import useDebounce from '../../hooks/useDebounce';
+import { useNavigation } from '@react-navigation/native';
 import { useThemeContext } from '@dooboo-ui/theme';
 
-export const fakeFriends: User[] = [
-  {
-    id: '1',
-    name: 'admin',
-    thumbURL: 'https://avatars2.githubusercontent.com/u/45788556?s=200&v=4',
-    photoURL: 'https://avatars2.githubusercontent.com/u/45788556?s=200&v=4',
-    statusMessage: 'this is my status message......',
-    isOnline: true,
-  },
-  {
-    id: '2',
-    name: 'geoseong',
-    thumbURL: 'https://avatars2.githubusercontent.com/u/19166187?s=460&v=4',
-    photoURL: 'https://avatars2.githubusercontent.com/u/19166187?s=460&v=4',
-    statusMessage: 'hi I am fine',
-    isOnline: false,
-  },
-  {
-    id: '3',
-    name: 'hyochan',
-    thumbURL: 'https://avatars2.githubusercontent.com/u/27461460?s=460&v=4',
-    photoURL: 'https://avatars2.githubusercontent.com/u/27461460?s=460&v=4',
-    statusMessage: 'hello',
-    isOnline: false,
-  },
-  {
-    id: '4',
-    name: 'mars',
-    thumbURL: 'https://avatars0.githubusercontent.com/u/6101260?s=460&v=4',
-    photoURL: 'https://avatars0.githubusercontent.com/u/6101260?s=460&v=4',
-    statusMessage: 'offline',
-    isOnline: true,
-  },
-  {
-    id: '5',
-    name: 'gordon',
-    thumbURL: 'https://avatars0.githubusercontent.com/u/10363850?s=460&v=4',
-    photoURL: 'https://avatars0.githubusercontent.com/u/10363850?s=460&v=4',
-    statusMessage: 'offline',
-    isOnline: true,
-  },
-  {
-    id: '6',
-    name: 'admin2',
-    thumbURL: 'https://avatars3.githubusercontent.com/u/31645570?s=200&v=4',
-    photoURL: 'https://avatars3.githubusercontent.com/u/31645570?s=200&v=4',
-    statusMessage: 'how are you',
-    isOnline: true,
-  },
-  {
-    id: '7',
-    name: 'geoseong2',
-    thumbURL:
-      'https://blogpfthumb-phinf.pstatic.net/20151226_89/imf4_1451062410452TqxER_JPEG/20120428000007_1.jpg',
-    photoURL:
-      'https://blogpfthumb-phinf.pstatic.net/20151226_89/imf4_1451062410452TqxER_JPEG/20120428000007_1.jpg',
-    statusMessage: 'offline',
-    isOnline: false,
-  },
-  {
-    id: '8',
-    name: 'hyochan2',
-    thumbURL:
-      'https://i.ytimg.com/vi/NgKSEvqzYvo/hqdefault.jpg?sqp=-oaymwEZCPYBEIoBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAWBWqCeP5oTwaB6XMRGXEhvbIiIA',
-    photoURL:
-      'https://i.ytimg.com/vi/NgKSEvqzYvo/hqdefault.jpg?sqp=-oaymwEZCPYBEIoBSFXyq4qpAwsIARUAAIhCGAFwAQ==&rs=AOn4CLAWBWqCeP5oTwaB6XMRGXEhvbIiIA',
-    statusMessage: 'offline',
-    isOnline: false,
-  },
-  {
-    id: '9',
-    name: 'mars2',
-    thumbURL:
-      'https://github.com/marsinearth/violin-mockup/blob/master/static/favicons/android-chrome-192x192.png?raw=true',
-    photoURL:
-      'https://github.com/marsinearth/violin-mockup/blob/master/static/favicons/android-chrome-192x192.png?raw=true',
-    statusMessage: 'offline',
-    isOnline: true,
-  },
-  {
-    id: '10',
-    name: 'gordon2',
-    thumbURL:
-      'https://miro.medium.com/fit/c/256/256/2*rbUkfoA5vfuphYYULjIG_Q.png',
-    photoURL:
-      'https://miro.medium.com/fit/c/256/256/2*rbUkfoA5vfuphYYULjIG_Q.png',
-    statusMessage: 'offline',
-    isOnline: true,
-  },
-];
+const ITEM_CNT = 20;
 
 const Container = styled.SafeAreaView`
   flex: 1;
-  background-color: ${({ theme }): string => theme.background};
+  background-color: ${({ theme }): string => theme.backgroundDark};
   flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
 `;
 
 const FriendThumbView = styled.View`
@@ -128,31 +48,279 @@ const FriendThumbView = styled.View`
   width: 70px;
 `;
 
-interface Props {
-  navigation: RootStackNavigationProps<'default'>;
-}
-
-interface Friend extends User {
+interface ChannelCreate extends User {
   checked?: boolean;
 }
 
-function Page(props: Props): ReactElement {
-  const { navigation } = props;
+const friendsQuery = graphql`
+  query ChannelCreateFriendsQuery($first: Int!, $after: String, $searchText: String) {
+    ...ChannelCreate_friends @arguments(first: $first, after: $after, searchText: $searchText)
+  }
+`;
+
+const friendsFragment = graphql`
+  fragment ChannelCreate_friends on Query
+    @argumentDefinitions(
+      first: {type: "Int!"}
+      after: {type: "String"}
+      searchText: {type: "String"}
+    )
+    @refetchable(queryName: "ChannelCreateFriendsPaginationQuery") {
+      friends(first: $first, after: $after searchText: $searchText)
+      @connection(key: "ChannelCreate_friends") {
+        edges {
+          cursor
+          node {
+            id
+            email
+            name
+            nickname
+            thumbURL
+            photoURL
+            birthday
+            gender
+            phone
+            statusMessage
+            verified
+            lastSignedIn
+            isOnline
+            createdAt
+            updatedAt
+            deletedAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+`;
+
+type FriendsFragmentProps = {
+  friend: ChannelCreate_friends$key,
+  scrollY: Animated.Value,
+  searchArgs: ChannelCreateFriendsPaginationQueryVariables,
+};
+
+const FriendsFragment: FC<FriendsFragmentProps> = ({
+  friend,
+}) => {
+  const {
+    data,
+    loadNext,
+    isLoadingNext,
+    refetch,
+  } = usePaginationFragment<ChannelCreateFriendsPaginationQuery, ChannelCreate_friends$key>(
+    friendsFragment,
+    friend,
+  );
+
+  const friends = useMemo(() => {
+    return data.friends.edges?.filter(
+      (x): x is NonNullable<typeof x> => x !== null,
+    ) || [];
+  }, [data]);
+
   const { theme } = useThemeContext();
-  const [searchText, setSearchText] = useState<string>('');
-  const [friends, setFriends] = useState<Friend[]>(fakeFriends);
+  // const [friends, setFriends] = useState<Friend[]>(fakeFriends);
 
-  const pressDone = (): void => {
-    const filtered = friends.filter((v) => (v.checked === true));
+  const navigation = useNavigation();
 
-    console.log('filtered', filtered);
+  // const renderFriendThumbnail = (friend: Friend, index: number): ReactElement => {
+  //   return <FriendThumbView key={friend.id}>
+  //     <View
+  //       style={{
+  //         marginTop: 12,
+  //         marginRight: 16,
+  //         marginBottom: 6,
+  //         justifyContent: 'center',
+  //         alignItems: 'center',
+  //       }}
+  //     >
+  //       <Image
+  //         style={{
+  //           width: 60,
+  //           height: 60,
+  //         }}
+  //         source={
+  //           friend.thumbURL
+  //             ? { uri: friend.thumbURL }
+  //             : IC_NO_IMAGE
+  //         }
+  //       />
+  //       <Text
+  //         numberOfLines={1}
+  //         style={{
+  //           fontSize: 12,
+  //           color: theme.fontColor,
+  //         }}
+  //       >{friend.nickname}</Text>
+  //     </View>
+  //     <TouchableOpacity
+  //       testID={`remove-${index}`}
+  //       style={{
+  //         position: 'absolute',
+  //         top: 0,
+  //         right: 0,
+  //       }}
+  //       onPress={(): void => removeFriend(friend)}
+  //     >
+  //       <Image source={IC_CIRCLE_X} style={{ width: 32, height: 32 }}/>
+  //     </TouchableOpacity>
+  //   </FriendThumbView>;
+  // };
+
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: UserEdge;
+    index: number;
+  }): ReactElement => {
+    // const testID = `user-id-${index}`;
+    // const userListOnPressInlineFn = (): void => userListOnPress(item.node as User);
+
+    return (
+      <UserListItem
+        testID={`userlist_${index}`}
+        showCheckBox
+        // checked={item.checked}
+        // @ts-ignore
+        user={item.node}
+        onPress={(): void => {
+          // const nextState = produce(friends, (draftState) => {
+          //   draftState[index].checked = !item.checked;
+          // });
+
+          // setFriends(nextState);
+        }}
+      />
+    );
   };
+
+  return (
+    <Container>
+      <FlatList
+        style={{ alignSelf: 'stretch' }}
+        contentContainerStyle={
+          friends.length === 0
+            ? {
+              flex: 1,
+              alignSelf: 'stretch',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }
+            : null
+        }
+        keyExtractor={(_, index): string => index.toString()}
+        data={friends}
+        renderItem={renderItem}
+        // ListHeaderComponent={(): ReactElement => {
+        //   const filtered = friends.filter((v) => (v.checked === true));
+
+        //   return <ScrollView
+        //     style={{ paddingHorizontal: 24, marginBottom: 12 }}
+        //     horizontal
+        //   >
+        //     {filtered.map((friend, i) => renderFriendThumbnail(friend, i))}
+        //   </ScrollView>;
+        // }}
+        ListEmptyComponent={
+          <ErroView
+            testID="btn-error"
+            title={getString('NO_FRIEND')}
+            body={getString('NO_FRIEND_BODY')}
+            buttonText={getString('GO_BACK')}
+            onButtonPressed={(): void => navigation.goBack()}
+          />
+        }
+      />
+    </Container>
+  );
+};
+
+interface ContentProps {
+  scrollY: Animated.Value,
+  searchArgs: ChannelCreateFriendsPaginationQueryVariables;
+}
+
+const ContentContainer: FC<ContentProps> = ({
+  searchArgs,
+  scrollY,
+}) => {
+  const queryResponse = useLazyLoadQuery<ChannelCreateFriendsQuery>(
+    friendsQuery,
+    { first: ITEM_CNT },
+    { fetchPolicy: 'store-or-network' },
+  );
+
+  return <FriendsFragment
+    friend={queryResponse}
+    scrollY={scrollY}
+    searchArgs={searchArgs}
+  />;
+};
+
+interface ChannelCreateProps {
+  navigation: RootStackNavigationProps<'default'>;
+}
+
+const ChannelCreate: FC<ChannelCreateProps> = (props) => {
+  const { navigation } = props;
+  const [searchText, setSearchText] = useState<string>('');
+  const debouncedText = useDebounce(searchText, 500);
+  const scrollY = new Animated.Value(0);
+
+  const searchArgs: ChannelCreateFriendsPaginationQueryVariables = {
+    first: ITEM_CNT,
+    searchText: debouncedText,
+  };
+
+  const onChangeText = (text: string): void => {
+    setSearchText(text);
+    scrollY.setValue(0);
+
+    Animated.timing(scrollY, {
+      useNativeDriver: true,
+      toValue: 100,
+      duration: 500,
+    }).start();
+  };
+
+  // const onChangeText = (text: string): void => {
+  //   if (!text) {
+  //     setFriends(fakeFriends);
+  //   } else {
+  //     const filtered = friends.filter((v) => (v.name?.includes(searchText)));
+
+  //     setFriends(filtered);
+  //   }
+
+  //   setSearchText(text);
+  // };
+
+  // const removeFriend = (friend: Friend): void => {
+  //   const nextState = produce(friends, (draftState) => {
+  //     const index = friends.findIndex((v) => v.id === friend.id);
+
+  //     draftState[index].checked = !friend.checked;
+  //   });
+
+  //   setFriends(nextState);
+  // };
+
+  // const pressDone = (): void => {
+  //   const filtered = friends.filter((v) => (v.checked === true));
+
+  //   console.log('filtered', filtered);
+  // };
 
   navigation.setOptions({
     headerRight: (): ReactElement => (
       <TouchableOpacity
         testID="touch-done"
-        onPress={pressDone}
+        // onPress={pressDone}
       >
         <View style={{
           paddingHorizontal: 16,
@@ -168,145 +336,21 @@ function Page(props: Props): ReactElement {
     ),
   });
 
-  const onChangeText = (text: string): void => {
-    if (!text) {
-      setFriends(fakeFriends);
-    } else {
-      const filtered = friends.filter((v) => (v.name?.includes(searchText)));
-
-      setFriends(filtered);
-    }
-
-    setSearchText(text);
-  };
-
-  const renderFriends = ({
-    item,
-    index,
-  }: {
-    item: Friend;
-    index: number;
-  }): ReactElement => {
-    return (
-      <UserListItem
-        testID={`userlist_${index}`}
-        showCheckBox
-        checked={item.checked}
-        user={item}
-        onPress={(): void => {
-          const nextState = produce(friends, (draftState) => {
-            draftState[index].checked = !item.checked;
-          });
-
-          setFriends(nextState);
-        }}
-      />
-    );
-  };
-
-  const removeFriend = (friend: Friend): void => {
-    const nextState = produce(friends, (draftState) => {
-      const index = friends.findIndex((v) => v.id === friend.id);
-
-      draftState[index].checked = !friend.checked;
-    });
-
-    setFriends(nextState);
-  };
-
-  const renderFriendThumbnail = (friend: Friend, index: number): ReactElement => {
-    return <FriendThumbView key={friend.id}>
-      <View
-        style={{
-          marginTop: 12,
-          marginRight: 16,
-          marginBottom: 6,
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <Image
-          style={{
-            width: 60,
-            height: 60,
-          }}
-          source={
-            friend.thumbURL
-              ? { uri: friend.thumbURL }
-              : IC_NO_IMAGE
-          }
-        />
-        <Text
-          numberOfLines={1}
-          style={{
-            fontSize: 12,
-            color: theme.fontColor,
-          }}
-        >{friend.nickname}</Text>
-      </View>
-      <TouchableOpacity
-        testID={`remove-${index}`}
-        style={{
-          position: 'absolute',
-          top: 0,
-          right: 0,
-        }}
-        onPress={(): void => removeFriend(friend)}
-      >
-        <Image source={IC_CIRCLE_X} style={{ width: 32, height: 32 }}/>
-      </TouchableOpacity>
-    </FriendThumbView>;
-  };
-
   return (
     <Container>
       <SearchTextInput
         testID="text-input"
         onChangeText={onChangeText}
         containerStyle={{
-          marginTop: 12,
+          marginVertical: 12,
         }}
         value={searchText}
       />
-      <FlatList
-        style={{
-          alignSelf: 'stretch',
-        }}
-        contentContainerStyle={
-          friends.length === 0
-            ? {
-              flex: 1,
-              alignSelf: 'stretch',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }
-            : null
-        }
-        keyExtractor={(_, index): string => index.toString()}
-        data={friends}
-        renderItem={renderFriends}
-        ListHeaderComponent={(): ReactElement => {
-          const filtered = friends.filter((v) => (v.checked === true));
-
-          return <ScrollView
-            style={{ paddingHorizontal: 24, marginBottom: 12 }}
-            horizontal
-          >
-            {filtered.map((friend, i) => renderFriendThumbnail(friend, i))}
-          </ScrollView>;
-        }}
-        ListEmptyComponent={
-          <ErroView
-            testID="btn-error"
-            title={getString('NO_FRIEND')}
-            body={getString('NO_FRIEND_BODY')}
-            buttonText={getString('GO_BACK')}
-            onButtonPressed={(): void => navigation.goBack()}
-          />
-        }
-      />
+      <Suspense fallback={<LoadingIndicator/>}>
+        <ContentContainer scrollY={scrollY} searchArgs={searchArgs}/>
+      </Suspense>
     </Container>
   );
-}
+};
 
-export default Page;
+export default ChannelCreate;

--- a/client/src/components/screen/ChannelCreate.tsx
+++ b/client/src/components/screen/ChannelCreate.tsx
@@ -349,7 +349,7 @@ const ChannelCreate: FC<ChannelCreateProps> = (props) => {
       ): void => {
         const channel = response.findOrCreatePrivateChannel;
 
-        navigation.navigate('Message', {
+        navigation.replace('Message', {
           users: selectedUsers,
           channel,
         });
@@ -400,6 +400,11 @@ const ChannelCreate: FC<ChannelCreateProps> = (props) => {
           setSelectedUsers={setSelectedUsers}
         />
       </Suspense>
+      {
+        isChannelInFlight
+          ? <LoadingIndicator/>
+          : null
+      }
     </Container>
   );
 };

--- a/client/src/components/screen/Friend.tsx
+++ b/client/src/components/screen/Friend.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactElement, useMemo } from 'react';
+import React, { FC, ReactElement, Suspense, useMemo } from 'react';
 import { User, UserEdge } from '../../types/graphql';
 import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay/hooks';
 
@@ -7,6 +7,7 @@ import { FlatList } from 'react-native';
 import { FriendFriendsPaginationQuery } from '../../__generated__/FriendFriendsPaginationQuery.graphql';
 import { FriendFriendsQuery } from '../../__generated__/FriendFriendsQuery.graphql';
 import { Friend_friends$key } from '../../__generated__/Friend_friends.graphql';
+import { LoadingIndicator } from 'dooboo-ui';
 import UserListItem from '../shared/UserListItem';
 import { getString } from '../../../STRINGS';
 import styled from 'styled-components/native';
@@ -119,38 +120,36 @@ const FriendsFragment: FC<FriendsFragmentProps> = ({
   };
 
   return (
-    <Container>
-      <FlatList
-        testID="friend-list"
-        style={{
-          alignSelf: 'stretch',
-        }}
-        contentContainerStyle={
-          friends.length === 0
-            ? {
-              flex: 1,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }
-            : undefined
-        }
-        keyExtractor={(item, index): string => index.toString()}
-        data={friends}
-        renderItem={renderItem}
-        ListEmptyComponent={
-          <EmptyListItem>{getString('NO_FRIENDLIST')}</EmptyListItem>
-        }
-        refreshing={isLoadingNext}
-        onRefresh={() => {
-          refetch(
-            { first: ITEM_CNT },
-            { fetchPolicy: 'network-only' },
-          );
-        }}
-        onEndReachedThreshold={0.1}
-        onEndReached={() => loadNext(ITEM_CNT)}
-      />
-    </Container>
+    <FlatList
+      testID="friend-list"
+      style={{
+        alignSelf: 'stretch',
+      }}
+      contentContainerStyle={
+        friends.length === 0
+          ? {
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }
+          : undefined
+      }
+      keyExtractor={(item, index): string => index.toString()}
+      data={friends}
+      renderItem={renderItem}
+      ListEmptyComponent={
+        <EmptyListItem>{getString('NO_FRIENDLIST')}</EmptyListItem>
+      }
+      refreshing={isLoadingNext}
+      onRefresh={() => {
+        refetch(
+          { first: ITEM_CNT },
+          { fetchPolicy: 'network-only' },
+        );
+      }}
+      onEndReachedThreshold={0.1}
+      onEndReached={() => loadNext(ITEM_CNT)}
+    />
   );
 };
 
@@ -164,4 +163,12 @@ const Friend: FC = () => {
   return <FriendsFragment friendsKey={queryResponse} />;
 };
 
-export default Friend;
+const Screen: FC = () => {
+  return <Container>
+    <Suspense fallback={<LoadingIndicator/>}>
+      <Friend/>
+    </Suspense>
+  </Container>;
+};
+
+export default Screen;

--- a/client/src/components/screen/Message.tsx
+++ b/client/src/components/screen/Message.tsx
@@ -524,7 +524,7 @@ interface Props {
 }
 
 const MessageScreen: FC<Props> = (props) => {
-  const { route: { params: { user, channel } } } = props;
+  const { route: { params: { users, channel } } } = props;
   const navigation = useNavigation();
 
   navigation.setOptions({
@@ -532,8 +532,14 @@ const MessageScreen: FC<Props> = (props) => {
       let title = channel?.name || '';
 
       // Note that if the user exists, this is direct message which title should appear as user name or nickname
-      if (user) {
-        title = user.nickname || user.name || '';
+      if (users) {
+        if (users.length === 1) {
+          title = users[0].nickname || users[0].name || '';
+        } else {
+          const userNames = users.map((v) => v.nickname ?? v.name);
+
+          title = userNames.join(', ');
+        }
       }
 
       return <Text style={{

--- a/client/src/components/screen/Message.tsx
+++ b/client/src/components/screen/Message.tsx
@@ -319,6 +319,8 @@ const MessagesFragment: FC<MessageProp> = ({
       onCompleted: (response: MessageCreateMutationResponse) => {
         const { text } = response.createMessage;
 
+        setTextToSend('');
+
         console.log('createMessage', text);
       },
       onError: (error: Error): void => {
@@ -548,11 +550,14 @@ const MessageScreen: FC<Props> = (props) => {
         }
       }
 
-      return <Text style={{
-        color: 'white',
-        fontSize: 18,
-        fontWeight: '500',
-      }}>{title}</Text>;
+      return <Text
+        style={{
+          color: 'white',
+          fontSize: 18,
+          fontWeight: '500',
+        }}
+        numberOfLines={2}
+      >{title}</Text>;
     },
   });
 

--- a/client/src/components/screen/Message.tsx
+++ b/client/src/components/screen/Message.tsx
@@ -1,3 +1,5 @@
+import * as Notifications from 'expo-notifications';
+
 import { Button, LoadingIndicator } from 'dooboo-ui';
 import { ConnectionHandler, RecordSourceSelectorProxy } from 'relay-runtime';
 import { Image, Platform, Text, TouchableOpacity, View } from 'react-native';
@@ -265,6 +267,16 @@ const MessagesFragment: FC<MessageProp> = ({
     messagesFragment,
     messages,
   );
+
+  useEffect(() => {
+    // Add notification handler.
+    const responseListener = Notifications.addNotificationReceivedListener((event) => {
+      loadPrevious(ITEM_CNT);
+    });
+
+    // Clean up : remove notification handler.
+    return () => Notifications.removeNotificationSubscription(responseListener);
+  }, [data]);
 
   const nodes = useMemo(
     () => {

--- a/client/src/components/screen/Message.tsx
+++ b/client/src/components/screen/Message.tsx
@@ -294,6 +294,7 @@ const MessagesFragment: FC<MessageProp> = ({
   };
 
   const [textToSend, setTextToSend] = useState<string>('');
+  const [isImageUploading, setIsImageUploading] = useState<boolean>(false);
   const { showModal } = useProfileContext();
 
   const [commitMessage, isMessageInFlight] = useMutation<MessageCreateMutation>(createMessage);
@@ -330,6 +331,8 @@ const MessagesFragment: FC<MessageProp> = ({
 
   const onRequestImagePicker = async (type: string): Promise<void> => {
     let image;
+
+    setIsImageUploading(true);
 
     if (type === 'photo') {
       image = await launchImageLibraryAsync();
@@ -370,11 +373,14 @@ const MessagesFragment: FC<MessageProp> = ({
         },
         onError: (error: Error): void => {
           console.log('error', error);
+          setIsImageUploading(false);
         },
       };
 
       commitMessage(mutationConfig);
     }
+
+    setIsImageUploading(false);
   };
 
   return <GiftedChat
@@ -484,7 +490,7 @@ const MessagesFragment: FC<MessageProp> = ({
             color: theme.btnPrimaryFont,
           },
         }}
-        loading={isMessageInFlight}
+        loading={isMessageInFlight || isImageUploading}
         onPress={onSubmit}
         text={getString('SEND')}
         textProps={{

--- a/client/src/components/screen/SearchUser.tsx
+++ b/client/src/components/screen/SearchUser.tsx
@@ -197,7 +197,7 @@ const ContentContainer: FC<ContentProps> = ({
 
 const Screen: FC = () => {
   const [searchText, setSearchText] = useState<string>('');
-  const debouncedText = useDebounce(searchText, 30);
+  const debouncedText = useDebounce(searchText, 500);
   const environment = useRelayEnvironment();
   const scrollY = new Animated.Value(0);
 

--- a/client/src/components/shared/GiftedChat.tsx
+++ b/client/src/components/shared/GiftedChat.tsx
@@ -1,4 +1,14 @@
-import { EmitterSubscription, FlatList, Keyboard, ListRenderItem, Platform, TextInput, View } from 'react-native';
+import {
+  BackHandler,
+  EmitterSubscription,
+  FlatList,
+  Keyboard,
+  ListRenderItem,
+  NativeEventSubscription,
+  Platform,
+  TextInput,
+  View,
+} from 'react-native';
 import React, { useEffect, useRef, useState } from 'react';
 
 import styled from 'styled-components/native';
@@ -73,6 +83,8 @@ interface Props<T> {
 
 function Shared<T>(props: Props<T>): React.ReactElement {
   let keyboardShowListener: EmitterSubscription;
+  let backHandlerListner: NativeEventSubscription;
+
   // NOTE: typings are not working well with useRef
   const input1 = useRef<TextInput>();
   const input2 = useRef<TextInput>();
@@ -105,6 +117,16 @@ function Shared<T>(props: Props<T>): React.ReactElement {
   }, [showMenu]);
 
   useEffect(() => {
+    backHandlerListner = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (showMenu) {
+        setShowMenu(false);
+
+        return true;
+      }
+
+      return false;
+    });
+
     keyboardShowListener = Keyboard.addListener('keyboardDidShow', (e) => {
       setKeyboardHeight(e.endCoordinates.height);
     });
@@ -112,6 +134,10 @@ function Shared<T>(props: Props<T>): React.ReactElement {
     return (): void => {
       if (keyboardShowListener) {
         keyboardShowListener.remove();
+      }
+
+      if (backHandlerListner) {
+        backHandlerListner.remove();
       }
     };
   }, []);

--- a/client/src/components/shared/MessageListItem.tsx
+++ b/client/src/components/shared/MessageListItem.tsx
@@ -46,11 +46,6 @@ const StyledPhotoContainer = styled.View`
   border-width: 1px;
 `;
 
-const StyledPhotoMessage = styled.Image`
-  width: 200px;
-  height: 200px;
-`;
-
 const StyledTextPeerName = styled.Text`
   font-size: 12px;
   color: ${({ theme }): string => theme.fontColor};

--- a/client/src/components/shared/MessageListItem.tsx
+++ b/client/src/components/shared/MessageListItem.tsx
@@ -2,6 +2,7 @@ import React, { SFC } from 'react';
 import { TouchableOpacity, View } from 'react-native';
 
 import { IC_NO_IMAGE } from '../../utils/Icons';
+import Image from 'react-native-scalable-image';
 import { Message } from '../../types/graphql';
 import moment from 'moment';
 import styled from 'styled-components/native';
@@ -196,9 +197,10 @@ function MessageListItem<T>(props: Props<T & Message>): React.ReactElement {
               {
                 imageUrls && imageUrls.length > 0
                   ? <StyledPhotoContainer>
-                    <StyledPhotoMessage source={{
-                      uri: imageUrls[0] as string,
-                    }} />
+                    <Image
+                      width={240}
+                      source={{ uri: imageUrls[0] as string }}
+                    />
                   </StyledPhotoContainer>
                   : <StyledPeerTextMessage>{text}</StyledPeerTextMessage>
               }
@@ -224,9 +226,10 @@ function MessageListItem<T>(props: Props<T & Message>): React.ReactElement {
         {
           imageUrls && imageUrls.length > 0
             ? <StyledPhotoContainer>
-              <StyledPhotoMessage source={{
-                uri: imageUrls[0] as string,
-              }} />
+              <Image
+                width={240}
+                source={{ uri: imageUrls[0] as string }}
+              />
             </StyledPhotoContainer>
             : <StyledMyTextMessage>{text}</StyledMyTextMessage>
         }

--- a/client/src/components/shared/ProfileModal.tsx
+++ b/client/src/components/shared/ProfileModal.tsx
@@ -80,8 +80,8 @@ const StyledTextFriendAlreadyAdded = styled.Text`
 `;
 
 const findOrCreatePrivateChannel = graphql`
-  mutation ProfileModalFindOrCreatePrivateChannelMutation($peerUserId: String!) {
-    findOrCreatePrivateChannel(peerUserId: $peerUserId) {
+  mutation ProfileModalFindOrCreatePrivateChannelMutation($peerUserIds: [String]!) {
+    findOrCreatePrivateChannel(peerUserIds: $peerUserIds) {
       id
       name
     }
@@ -229,7 +229,7 @@ const ModalContent: FC<ModalContentProps> = ({
         hideModal();
 
         navigation.navigate('Message', {
-          user,
+          users: [user],
           channel,
         });
       },

--- a/client/src/components/shared/UserListItem.tsx
+++ b/client/src/components/shared/UserListItem.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 const Container = styled.View`
   width: 100%;
+  background-color: blue;
 `;
 
 const Wrapper = styled.View`

--- a/client/src/components/shared/UserListItem.tsx
+++ b/client/src/components/shared/UserListItem.tsx
@@ -20,7 +20,6 @@ interface Props {
 
 const Container = styled.View`
   width: 100%;
-  background-color: blue;
 `;
 
 const Wrapper = styled.View`

--- a/client/test/jestSetup.ts
+++ b/client/test/jestSetup.ts
@@ -33,6 +33,8 @@ jest.mock('expo-constants', () => ({
 
 jest.mock('src/components/shared/SocialSignInButton', () => 'test');
 
+jest.mock('react-native-scalable-image', () => 'test');
+
 // Mock dooboo-ui because it is causing cyclic reference issue that
 // breaks jest snapshot serializer.
 jest.mock('dooboo-ui', () => {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13524,6 +13524,11 @@ react-native-safe-area-context@3.1.4:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-3.1.4.tgz#9b7f883a5ae8da6218d17467a350434005893602"
   integrity sha512-bXx3hqz4LovFoMnJIRGIWL2oJ/PHadXviBKvgZV9yNErtURQLJSn0yfQytVtiqslhaBMZOJwH4R6HiClyofvBg==
 
+react-native-scalable-image@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-scalable-image/-/react-native-scalable-image-1.0.0.tgz#2751a02c2610b4266eb06ce0d466fb1eff266127"
+  integrity sha512-Hcizro1eh7GhelTIjpAYi6WR8ybHNFkMMPSpEeMNI6u1Lxt7b6o97MM9r7+g8hlUjKUlNPQvwaqcf+rW75sSfg==
+
 react-native-screens@~2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.10.1.tgz#06d22fae87ef0ce51c616c34a199726db1403b95"


### PR DESCRIPTION
## Specify project
client

## Description
[ChannelCreate] screen had only design implementation. Integrate with relay fragment pagination to associate with real queries.

Add ability to render [ChannelListItem] for multi-users. Group chat for `private` is now possible.

![image](https://user-images.githubusercontent.com/27461460/98389580-995b9a80-2097-11eb-83b6-6be4c84862c6.png)


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
