### PR TITLE
Load Channel Connection on Notification Received

### DIFF
--- a/client/src/components/screen/Channel.tsx
+++ b/client/src/components/screen/Channel.tsx
@@ -176,6 +176,8 @@ const ChannelsFragment: FC<ChannelProps> = ({
     const responseListener = Notifications.addNotificationReceivedListener((event) => {
       const messageId = JSON.parse(event.request.content.data.data as string).messageId;
 
+      loadNext(ITEM_CNT);
+
       if (typeof messageId === 'string') {
         loadLastMessage({ messageId });
       }


### PR DESCRIPTION
## Specify project
client

## Description

When a message is received from a channel not in the relay store, `Channel` screen was not updating the list of channels.
Check for newly created channel when a notification is received.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
