### PR TITLE
Refactor context and use userId directly

### DIFF
--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -1,26 +1,28 @@
 import { PrismaClient } from '@prisma/client';
 import { PubSub } from 'graphql-subscriptions';
-import { Request } from 'apollo-server';
+import { getUserId } from './utils/auth';
 
 export const prisma = new PrismaClient();
 const { JWT_SECRET, JWT_SECRET_ETC } = process.env;
 
 export interface Context {
-  request: Request & any;
+  request: { req: ReqI18n };
   prisma: PrismaClient;
   pubsub: PubSub;
   appSecret: string;
   appSecretEtc: string;
+  userId: string;
 }
 
 const pubsub = new PubSub();
 
-export function createContext(request: Request): Context {
+export function createContext(request: { req: ReqI18n }): Context {
   return {
     request,
     prisma,
     pubsub,
     appSecret: JWT_SECRET,
     appSecretEtc: JWT_SECRET_ETC,
+    userId: getUserId(request),
   };
 }

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,5 +1,4 @@
 import { NexusGenRootTypes } from '../generated/nexus';
-import { getUserId } from '../utils/auth';
 import { objectType } from '@nexus/schema';
 import { prisma } from '../context';
 
@@ -36,10 +35,8 @@ export const User = objectType({
     t.boolean('hasBlocked', {
       description: 'Check if the user is blocked by the user who have signed in.',
 
-      resolve: async ({ id }, args, ctx) => {
-        const userId = getUserId(ctx);
-
-        const blockedUser = await ctx.prisma.blockedUser.findFirst({
+      resolve: async ({ id }, args, { prisma, userId }) => {
+        const blockedUser = await prisma.blockedUser.findFirst({
           where: { userId, blockedUserId: id },
         });
 

--- a/server/src/resolvers/BlockedUser/mutation.ts
+++ b/server/src/resolvers/BlockedUser/mutation.ts
@@ -1,7 +1,5 @@
 import { mutationField, nonNull, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
-
 export const createBlockedUser = mutationField('createBlockedUser', {
   type: 'BlockedUser',
 
@@ -9,20 +7,17 @@ export const createBlockedUser = mutationField('createBlockedUser', {
     blockedUserId: nonNull(stringArg()),
   },
 
-  resolve: (_, { blockedUserId }, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.blockedUser.create({
+  resolve: (_,
+    { blockedUserId },
+    { prisma, userId },
+  ) => {
+    return prisma.blockedUser.create({
       data: {
         user: {
-          connect: {
-            id: userId,
-          },
+          connect: { id: userId },
         },
         blockedUser: {
-          connect: {
-            id: blockedUserId,
-          },
+          connect: { id: blockedUserId },
         },
       },
       include: {
@@ -40,10 +35,11 @@ export const deleteBlockedUser = mutationField('deleteBlockedUser', {
     blockedUserId: nonNull(stringArg()),
   },
 
-  resolve: (_, { blockedUserId }, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.blockedUser.delete({
+  resolve: (_,
+    { blockedUserId },
+    { prisma, userId },
+  ) => {
+    return prisma.blockedUser.delete({
       where: {
         userId_blockedUserId: {
           userId,

--- a/server/src/resolvers/BlockedUser/query.ts
+++ b/server/src/resolvers/BlockedUser/query.ts
@@ -1,21 +1,13 @@
 import { list, queryField } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
-
 export const blockedUsers = queryField('blockedUsers', {
   type: list('User'),
   description: 'Arguments are not needed. Only find blocked users of signed in user',
 
-  resolve: async (_, __, ctx) => {
-    const userId = getUserId(ctx);
-
-    const blockedUsers = await ctx.prisma.blockedUser.findMany({
-      select: {
-        blockedUser: true,
-      },
-      where: {
-        userId,
-      },
+  resolve: async (_, __, { prisma, userId }) => {
+    const blockedUsers = await prisma.blockedUser.findMany({
+      select: { blockedUser: true },
+      where: { userId },
     });
 
     return blockedUsers.map((user) => user.blockedUser);

--- a/server/src/resolvers/Channel/query.ts
+++ b/server/src/resolvers/Channel/query.ts
@@ -1,6 +1,5 @@
 import { booleanArg, queryField, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const channel = queryField('channel', {
@@ -23,8 +22,7 @@ export const channels = queryField((t) => {
       withMessage: booleanArg(),
     },
 
-    async nodes(_, args, ctx) {
-      const userId = getUserId(ctx);
+    async nodes(_, args, { prisma, userId }) {
       const { after, before, first, last, withMessage } = args;
 
       const checkMessage = withMessage && {
@@ -35,7 +33,7 @@ export const channels = queryField((t) => {
         },
       };
 
-      return ctx.prisma.channel.findMany({
+      return prisma.channel.findMany({
         ...relayToPrismaPagination({
           after, before, first, last,
         }),

--- a/server/src/resolvers/Friend/mutation.ts
+++ b/server/src/resolvers/Friend/mutation.ts
@@ -1,7 +1,5 @@
 import { mutationField, nonNull, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
-
 export const addFriend = mutationField('addFriend', {
   type: 'Friend',
 
@@ -9,10 +7,8 @@ export const addFriend = mutationField('addFriend', {
     friendId: nonNull(stringArg()),
   },
 
-  resolve: (_, { friendId }, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.friend.create({
+  resolve: (_, { friendId }, { prisma, userId }) => {
+    return prisma.friend.create({
       data: {
         user: {
           connect: {
@@ -38,10 +34,8 @@ export const deleteFriend = mutationField('deleteFriend', {
   args: {
     friendId: nonNull(stringArg()),
   },
-  resolve: (_, { friendId }, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.friend.delete({
+  resolve: (_, { friendId }, { prisma, userId }) => {
+    return prisma.friend.delete({
       where: {
         userId_friendId: {
           userId,

--- a/server/src/resolvers/Friend/query.ts
+++ b/server/src/resolvers/Friend/query.ts
@@ -1,6 +1,5 @@
 import { queryField, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const friends = queryField((t) => {
@@ -11,8 +10,7 @@ export const friends = queryField((t) => {
       searchText: stringArg(),
     },
 
-    async nodes(_, args, ctx) {
-      const userId = getUserId(ctx);
+    async nodes(_, args, { prisma, userId }) {
       const { after, before, first, last, searchText } = args;
 
       const filter = searchText && {
@@ -23,7 +21,7 @@ export const friends = queryField((t) => {
         ],
       };
 
-      return ctx.prisma.user.findMany({
+      return prisma.user.findMany({
         ...relayToPrismaPagination({
           after, before, first, last,
         }),

--- a/server/src/resolvers/Message/query.ts
+++ b/server/src/resolvers/Message/query.ts
@@ -1,6 +1,5 @@
 import { nonNull, queryField, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const message = queryField('message', {
@@ -25,8 +24,7 @@ export const messages = queryField((t) => {
       searchText: stringArg(),
     },
 
-    async nodes(_, args, ctx) {
-      const userId = getUserId(ctx);
+    async nodes(_, args, { prisma, userId }) {
       const { after, before, first, last, searchText, channelId } = args;
 
       const filter = searchText && {
@@ -35,12 +33,12 @@ export const messages = queryField((t) => {
         ],
       };
 
-      const blockedUsersIds = (await ctx.prisma.blockedUser.findMany({
+      const blockedUsersIds = (await prisma.blockedUser.findMany({
         select: { blockedUserId: true },
         where: { userId },
       })).map((user) => user.blockedUserId);
 
-      return ctx.prisma.message.findMany({
+      return prisma.message.findMany({
         ...relayToPrismaPagination({
           after, before, first, last,
         }),

--- a/server/src/resolvers/Notification/mutation.ts
+++ b/server/src/resolvers/Notification/mutation.ts
@@ -1,7 +1,5 @@
 import { mutationField, nonNull, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
-
 export const createNotification = mutationField('createNotification', {
   type: 'Notification',
 
@@ -11,10 +9,8 @@ export const createNotification = mutationField('createNotification', {
     os: stringArg(),
   },
 
-  resolve: (parent, { token, device, os }, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.notification.create({
+  resolve: (parent, { token, device, os }, { prisma, userId }) => {
+    return prisma.notification.create({
       data: {
         token,
         device,
@@ -29,8 +25,8 @@ export const deleteNotification = mutationField('deleteNotification', {
   type: 'Notification',
   args: { token: nonNull(stringArg()) },
 
-  resolve: (parent, { token }, ctx) => {
-    return ctx.prisma.notification.delete({
+  resolve: (parent, { token }, { prisma }) => {
+    return prisma.notification.delete({
       where: {
         token,
       },

--- a/server/src/resolvers/Report/mutation.ts
+++ b/server/src/resolvers/Report/mutation.ts
@@ -1,8 +1,6 @@
 import SendGridMail, { MailDataRequired } from '@sendgrid/mail';
 import { mutationField, nonNull, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
-
 const { SENDGRID_EMAIL } = process.env;
 
 export const createReport = mutationField('createReport', {
@@ -13,19 +11,17 @@ export const createReport = mutationField('createReport', {
     report: nonNull(stringArg()),
   },
 
-  resolve: async (_, { reportedUserId, report }, ctx) => {
-    const userId = getUserId(ctx);
-
+  resolve: async (_, { reportedUserId, report }, { prisma, request, userId }) => {
     const msg: MailDataRequired = {
       to: 'hackatalk@gmail.com',
       from: SENDGRID_EMAIL,
-      subject: `${ctx.request.req.t('USER_REPORTED')} - ${reportedUserId}`,
+      subject: `${request.req.t('USER_REPORTED')} - ${reportedUserId}`,
       text: `The user (${userId}) has reported ${reportedUserId}.\n\nmessage: ${report}.`,
     };
 
     await SendGridMail.send(msg);
 
-    return ctx.prisma.report.create({
+    return prisma.report.create({
       data: {
         report,
         user: {

--- a/server/src/resolvers/User/query.ts
+++ b/server/src/resolvers/User/query.ts
@@ -1,6 +1,5 @@
 import { queryField, stringArg } from '@nexus/schema';
 
-import { getUserId } from '../../utils/auth';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const user = queryField('user', {
@@ -31,9 +30,8 @@ export const userConnection = queryField((t) => {
     description:
       'Query users with relay pagination. This is filterable but it will not return user itself and the blocked users.',
 
-    async nodes(_, args, ctx) {
+    async nodes(_, args, { prisma, userId }) {
       const { after, before, first, last, searchText } = args;
-      const userId = getUserId(ctx);
 
       const filter = searchText && {
         OR: [
@@ -43,7 +41,7 @@ export const userConnection = queryField((t) => {
         ],
       };
 
-      return ctx.prisma.user.findMany({
+      return prisma.user.findMany({
         ...relayToPrismaPagination({
           after, before, first, last,
         }),
@@ -65,10 +63,8 @@ export const me = queryField('me', {
   type: 'User',
   description: 'Fetch current user profile when authenticated.',
 
-  resolve: (parent, args, ctx) => {
-    const userId = getUserId(ctx);
-
-    return ctx.prisma.user.findUnique({
+  resolve: (parent, args, { prisma, userId }) => {
+    return prisma.user.findUnique({
       where: {
         id: userId,
       },

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -34,15 +34,15 @@ interface Token {
   userId: string;
 }
 
-export function getUserId(context: Context): string {
-  const Authorization = context.request.req.get('Authorization');
+export function getUserId({ req }: {req: ReqI18n}): string {
+  const Authorization = req?.get?.('Authorization');
 
-  if (Authorization) {
-    const token = Authorization.replace('Bearer ', '');
-    const verifiedToken = verify(token, APP_SECRET) as Token;
+  if (!Authorization) return;
 
-    return verifiedToken && verifiedToken.userId;
-  }
+  const token = Authorization.replace('Bearer ', '');
+  const verifiedToken = verify(token, APP_SECRET) as Token;
+
+  return verifiedToken && verifiedToken.userId;
 }
 
 export const validateEmail = (email: string): boolean => {


### PR DESCRIPTION
## Specify project
Server

## Description

Remove every import statements that need to get user id and instead pass that into context. Since this is not heavy work and it just checks Authorization if not included, it is fine to run checks on userId in every request.


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
