### PR TITLE
Add [createTestContext] with Mocked Prisma Client

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.1.0",
+    "get-port": "^5.1.1",
     "graphql-import": "^1.0.2",
     "graphql-request": "^3.3.0",
     "graphql-tag": "^2.11.0",

--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -16,13 +16,13 @@ export interface Context {
 
 const pubsub = new PubSub();
 
-export function createContext(request: { req: ReqI18n }): Context {
-  return {
+export const createContext = (prisma: PrismaClient) => {
+  return (request: { req: ReqI18n }): Context => ({
     request,
     prisma,
     pubsub,
     appSecret: JWT_SECRET,
     appSecretEtc: JWT_SECRET_ETC,
     userId: getUserId(request),
-  };
-}
+  });
+};

--- a/server/tests/createTestContext.ts
+++ b/server/tests/createTestContext.ts
@@ -1,0 +1,74 @@
+import { createApolloServer, startServer } from '../src/server';
+import getPort, { makeRange } from 'get-port';
+
+import { Context } from '../src/context';
+import { GraphQLClient } from 'graphql-request';
+import { PrismaClient } from '@prisma/client';
+import { PubSub } from 'apollo-server';
+import { createApp } from '../src/app';
+
+type MockPrisma = {
+  [P in keyof PrismaClient]: PrismaClient[P] & {
+    [Q in keyof PrismaClient[P]]: jest.Mock
+  }
+}
+
+interface TestContext extends Context {
+  prisma: MockPrisma & PrismaClient,
+  client: GraphQLClient,
+}
+
+/**
+ * Create prisma client with all methods mocked.
+ */
+const createMockPrisma = () => {
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  // !                  IMPORTANT ISSUE                       !
+  // ! Because `PrismaClient` class is dynamically generated, !
+  // ! `PrismaClient.prototype` does not have model getters   !
+  // ! such as `prisma.user`.                                 !
+  // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  const ret = Object.create(PrismaClient.prototype);
+
+  for (const k in ret) {
+    ret[k] = jest.fn();
+  }
+
+  return ret;
+};
+
+/**
+ * Create pubsub with all methods mocked..
+ */
+const createPubSub = () => {
+  const ret = Object.create(PubSub.prototype);
+
+  for (const k in ret) {
+    ret[k] = jest.fn();
+  }
+
+  return ret;
+};
+
+export const createTestContext = async (): Promise<TestContext> => {
+  const mockPrisma = createMockPrisma();
+  const mockPubSub = createPubSub();
+  const app = createApp();
+
+  const apollo = createApolloServer(mockPrisma);
+  const port = await getPort({ port: makeRange(4000, 6000) });
+
+  await startServer(app, apollo, port);
+
+  const graphqlClient = new GraphQLClient(`http://localhost:${port}`);
+
+  return {
+    request: { req: undefined },
+    userId: 'abcd123',
+    appSecret: 'very-secure',
+    appSecretEtc: 'another-secure',
+    pubsub: mockPubSub,
+    prisma: mockPrisma,
+    client: graphqlClient,
+  };
+};

--- a/server/tests/e2e/testSetup.ts
+++ b/server/tests/e2e/testSetup.ts
@@ -1,3 +1,5 @@
+import { createApolloServer, startServer } from '../../src/server';
+
 import ApolloClient from 'apollo-client';
 import { Headers } from 'cross-fetch';
 import { Http2Server } from 'http2';
@@ -9,7 +11,6 @@ import { WebSocketLink } from 'apollo-link-ws';
 import { createApp } from '../../src/app';
 import { exec } from 'child_process';
 import express from 'express';
-import { startServer } from '../../src/server';
 
 // @ts-ignore
 global.Headers = global.Headers || Headers;
@@ -24,8 +25,9 @@ const testSubscriptionHost = `ws://localhost:${port}/graphql`;
 
 beforeAll(async (done) => {
   const app: express.Application = createApp();
+  const apollo = createApolloServer(prisma);
 
-  server = await startServer(app);
+  server = await startServer(app, apollo);
 
   networkInterface = new SubscriptionClient(
     testSubscriptionHost,

--- a/server/tests/simple.test.ts
+++ b/server/tests/simple.test.ts
@@ -1,0 +1,18 @@
+import { createTestContext } from './createTestContext';
+
+it('simple test with createTestContext', async () => {
+  const { prisma, client } = await createTestContext();
+
+  prisma.user.findUnique.mockImplementation(() => ({
+    id: '123',
+  }));
+
+  const res = await client.request(`
+    query {
+      me { id }
+    }
+  `);
+
+  // Test res here.
+  console.log(res);
+});

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3727,7 +3727,7 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-port@^5.1.0:
+get-port@^5.1.0, get-port@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==


### PR DESCRIPTION
## Specify project
server

## Description
- Refactor `createContext`, `createApolloServer` and `startServer` for dependency injection of prisma client & port number.
- Implement `createTestContext` function which generates a context with mock prisma client & allow concurrent testing.

## Tests
I added the following tests:
- `tests/simple.test.ts`: to demonstrate the new `createTestContext`.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
