### PR TITLE
Fix Styled Components Type Issue

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -123,7 +123,7 @@
     "@types/react-responsive": "^8.0.2",
     "@types/react-test-renderer": "^17.0",
     "@types/relay-test-utils": "^6.0.3",
-    "@types/styled-components": "^5.1.7",
+    "@types/styled-components-react-native": "^5.1.0",
     "abort-controller": "^3.0.0",
     "babel-jest": "^26.6.3",
     "babel-plugin-inline-dotenv": "^1.6.0",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": true,
-    "noImplicitAny": false,
     "noUnusedLocals": false,
     "skipLibCheck": true,
     "sourceMap": true,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3457,7 +3457,16 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/styled-components@^5.1.7":
+"@types/styled-components-react-native@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@types/styled-components-react-native/-/styled-components-react-native-5.1.0.tgz#58c3e58d53c789f71dfbd7396ec8f2f4ec5f169b"
+  integrity sha512-aUAikzt1d8FGgGbybBUgwcjIEhzE98kK3SXx3Zg7hhJMln4jtkvGddBj91uQmBqFCLb+4ox6EoFI02xOcs48yQ==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-native" "*"
+    "@types/styled-components" "*"
+
+"@types/styled-components@*":
   version "5.1.7"
   resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.7.tgz#3cd10b088c1cb1acde2e4b166b3e8275a3083710"
   integrity sha512-BJzPhFygYspyefAGFZTZ/8lCEY4Tk+Iqktvnko3xmJf9LrLqs3+grxPeU3O0zLl6yjbYBopD0/VikbHgXDbJtA==
@@ -16696,10 +16705,8 @@ watchpack@^1.6.1:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
## Specify project
client

## Description

`styled-components` package had type issue for over a year, and `noImplicitAny` option in `tsconfig.json` file was set to `false` as a temporary fix.
The notorious type issue is now resolved by separating RN types from `@types/styled-components`.
This PR re-enables `noImplicitAny` option and installs `@types/styled-components-react-native` package.

## Related Issues

If you want to watch angry people complaining about `@types/styped-components` read these issues:
1. https://github.com/styled-components/styled-components/issues/2370
2. https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29795
3. https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32843

Hackatalk adopted the temporary fix in this PR: https://github.com/dooboolab/hackatalk/pull/330

The long awaited upstream fix is merged here: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49914

Finally, here's the Definitely Typed package for RN styled components: [@types/styled-components-react-native](https://www.npmjs.com/package/@types/styled-components-react-native)

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
