### PR TITLE
Enable Strict Mode for Typescript

### DIFF
--- a/server/dotenv/test.env
+++ b/server/dotenv/test.env
@@ -1,8 +1,8 @@
 JWT_SECRET=dooboolab
 DATABASE_URL="postgresql://test:test!@localhost:5432/postgres?schema=test"
 
-SENDGRID_API_KEY=
-SENDGRID_EMAIL=
+SENDGRID_API_KEY=necessary
+SENDGRID_EMAIL="help@example.com"
 STORAGE_ACCOUNT=account
 STORAGE_KEY=key
 STORAGE_CONNECTION_STRING=

--- a/server/src/context.ts
+++ b/server/src/context.ts
@@ -1,9 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 import { PubSub } from 'graphql-subscriptions';
+import { assert } from './utils/assert';
 import { getUserId } from './utils/auth';
 
 export const prisma = new PrismaClient();
-const { JWT_SECRET, JWT_SECRET_ETC } = process.env;
 
 export interface Context {
   request: { req: ReqI18n };
@@ -11,12 +11,17 @@ export interface Context {
   pubsub: PubSub;
   appSecret: string;
   appSecretEtc: string;
-  userId: string;
+  userId: string | null;
 }
 
 const pubsub = new PubSub();
 
 export function createContext(request: { req: ReqI18n }): Context {
+  const { JWT_SECRET, JWT_SECRET_ETC } = process.env;
+
+  assert(JWT_SECRET, 'Missing JWT_SECRET environment variable.');
+  assert(JWT_SECRET_ETC, 'Missing JWT_SECRET_ETC environment variable.');
+
   return {
     request,
     prisma,

--- a/server/src/models/Channel.ts
+++ b/server/src/models/Channel.ts
@@ -1,5 +1,6 @@
 import { booleanArg, objectType } from 'nexus';
 
+import { assert } from '../utils/assert';
 import { relayToPrismaPagination } from '../utils/pagination';
 
 export const Channel = objectType({
@@ -35,7 +36,9 @@ export const Channel = objectType({
     t.connectionField('messages', {
       type: 'Message',
 
-      nodes: async ({ id }, args, { request, prisma, userId }) => {
+      nodes: async ({ id }, args, { prisma, userId }) => {
+        assert(userId, 'Not authorized.');
+
         const { after, before, first, last } = args;
 
         const blockedUsers = await prisma.blockedUser.findMany({
@@ -75,7 +78,7 @@ export const Channel = objectType({
             where: {
               channel: { id },
               user: {
-                id: { not: userId },
+                id: { not: userId ?? undefined },
               },
             },
             include: { user: true },

--- a/server/src/models/Scalar.ts
+++ b/server/src/models/Scalar.ts
@@ -13,7 +13,7 @@ export enum AuthType {
 export const Auth = scalarType({
   name: 'Auth',
   asNexusMethod: 'auth',
-  parseValue(value: AuthType): AuthType {
+  parseValue(value: AuthType): AuthType | undefined {
     if (AuthType[value]) {
       return value;
     }
@@ -31,7 +31,7 @@ export enum Gender {
 export const gender = scalarType({
   name: 'Gender',
   asNexusMethod: 'gender',
-  parseValue(value: Gender): Gender {
+  parseValue(value: Gender): Gender | undefined {
     if (Gender[value]) {
       return value;
     }
@@ -50,7 +50,7 @@ export enum MembershipType {
 export const membershipType = scalarType({
   name: 'MembershipType',
   asNexusMethod: 'membershipType',
-  parseValue(value: MembershipType): MembershipType {
+  parseValue(value: MembershipType): MembershipType | undefined {
     if (MembershipType[value]) {
       return value;
     }
@@ -69,7 +69,7 @@ export enum AlertMode {
 export const alertMode = scalarType({
   name: 'AlertMode',
   asNexusMethod: 'alertMode',
-  parseValue(value: AlertMode): AlertMode {
+  parseValue(value: AlertMode): AlertMode | undefined {
     if (AlertMode[value]) {
       return value;
     }
@@ -87,7 +87,7 @@ export enum ChannelType {
 export const channelType = scalarType({
   name: 'ChannelType',
   asNexusMethod: 'channelType',
-  parseValue(value: ChannelType): ChannelType {
+  parseValue(value: ChannelType): ChannelType | undefined {
     if (ChannelType[value]) {
       return value;
     }
@@ -106,7 +106,7 @@ export enum MessageType {
 export const messageType = scalarType({
   name: 'MessageType',
   asNexusMethod: 'messageType',
-  parseValue(value: MessageType): MessageType {
+  parseValue(value: MessageType): MessageType | undefined {
     if (MessageType[value]) {
       return value;
     }

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,4 +1,5 @@
 import { NexusGenRootTypes } from '../generated/nexus';
+import { assert } from '../utils/assert';
 import { objectType } from 'nexus';
 import { prisma } from '../context';
 
@@ -36,6 +37,8 @@ export const User = objectType({
       description: 'Check if the user is blocked by the user who have signed in.',
 
       resolve: async ({ id }, args, { prisma, userId }) => {
+        assert(userId, 'Not authorized.');
+
         const blockedUser = await prisma.blockedUser.findFirst({
           where: { userId, blockedUserId: id },
         });

--- a/server/src/resolvers/BlockedUser/mutation.ts
+++ b/server/src/resolvers/BlockedUser/mutation.ts
@@ -1,5 +1,7 @@
 import { mutationField, nonNull, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 export const createBlockedUser = mutationField('createBlockedUser', {
   type: 'BlockedUser',
 
@@ -11,6 +13,8 @@ export const createBlockedUser = mutationField('createBlockedUser', {
     { blockedUserId },
     { prisma, userId },
   ) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.blockedUser.create({
       data: {
         user: {
@@ -39,6 +43,8 @@ export const deleteBlockedUser = mutationField('deleteBlockedUser', {
     { blockedUserId },
     { prisma, userId },
   ) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.blockedUser.delete({
       where: {
         userId_blockedUserId: {

--- a/server/src/resolvers/BlockedUser/query.ts
+++ b/server/src/resolvers/BlockedUser/query.ts
@@ -1,10 +1,14 @@
 import { list, queryField } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 export const blockedUsers = queryField('blockedUsers', {
   type: list('User'),
   description: 'Arguments are not needed. Only find blocked users of signed in user',
 
   resolve: async (_, __, { prisma, userId }) => {
+    assert(userId, 'Not authorized.');
+
     const blockedUsers = await prisma.blockedUser.findMany({
       select: { blockedUser: true },
       where: { userId },

--- a/server/src/resolvers/Channel/query.ts
+++ b/server/src/resolvers/Channel/query.ts
@@ -1,10 +1,11 @@
-import { booleanArg, queryField, stringArg } from 'nexus';
+import { booleanArg, nonNull, queryField, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const channel = queryField('channel', {
   type: 'Channel',
-  args: { channelId: stringArg() },
+  args: { channelId: nonNull(stringArg()) },
   description: 'Get single channel',
 
   resolve: (parent, { channelId }, ctx) => ctx.prisma.channel.findUnique({
@@ -23,6 +24,8 @@ export const channels = queryField((t) => {
     },
 
     async nodes(_, args, { prisma, userId }) {
+      assert(userId, 'Not authorized.');
+
       const { after, before, first, last, withMessage } = args;
 
       const checkMessage = withMessage && {

--- a/server/src/resolvers/Friend/mutation.ts
+++ b/server/src/resolvers/Friend/mutation.ts
@@ -1,5 +1,7 @@
 import { mutationField, nonNull, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 export const addFriend = mutationField('addFriend', {
   type: 'Friend',
 
@@ -8,6 +10,8 @@ export const addFriend = mutationField('addFriend', {
   },
 
   resolve: (_, { friendId }, { prisma, userId }) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.friend.create({
       data: {
         user: {
@@ -35,6 +39,8 @@ export const deleteFriend = mutationField('deleteFriend', {
     friendId: nonNull(stringArg()),
   },
   resolve: (_, { friendId }, { prisma, userId }) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.friend.delete({
       where: {
         userId_friendId: {

--- a/server/src/resolvers/Friend/query.ts
+++ b/server/src/resolvers/Friend/query.ts
@@ -1,5 +1,6 @@
 import { queryField, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const friends = queryField((t) => {
@@ -11,6 +12,8 @@ export const friends = queryField((t) => {
     },
 
     async nodes(_, args, { prisma, userId }) {
+      assert(userId, 'Not authorized.');
+
       const { after, before, first, last, searchText } = args;
 
       const filter = searchText && {

--- a/server/src/resolvers/Message/mutation.ts
+++ b/server/src/resolvers/Message/mutation.ts
@@ -1,6 +1,8 @@
 import { ExpoMessage, getReceiversPushTokens, sendPushNotification } from '../../services/NotificationService';
 import { arg, mutationField, nonNull, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 export const createMessage = mutationField('createMessage', {
   type: 'Message',
 
@@ -12,6 +14,8 @@ export const createMessage = mutationField('createMessage', {
   },
 
   resolve: async (parent, { channelId, message }, { prisma, request, userId }) => {
+    assert(userId, 'Not authorized.');
+
     const { imageUrls, fileUrls, ...rest } = message;
 
     const created = await prisma.message.create({
@@ -47,7 +51,7 @@ export const createMessage = mutationField('createMessage', {
       const message: ExpoMessage = {
         to: token,
         sound: 'default',
-        title: created.sender.name,
+        title: created.sender.name ?? 'Anonymous',
         body: created.messageType === 'photo'
           ? request.req.t('PHOTO')
           : created.messageType === 'file'

--- a/server/src/resolvers/Message/query.ts
+++ b/server/src/resolvers/Message/query.ts
@@ -1,10 +1,11 @@
 import { nonNull, queryField, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const message = queryField('message', {
   type: 'Message',
-  args: { id: stringArg() },
+  args: { id: nonNull(stringArg()) },
   description: 'Get single message',
   resolve: (_, { id }, ctx) => ctx.prisma.message.findUnique({
     where: { id },
@@ -25,6 +26,8 @@ export const messages = queryField((t) => {
     },
 
     async nodes(_, args, { prisma, userId }) {
+      assert(userId, 'Not authorized.');
+
       const { after, before, first, last, searchText, channelId } = args;
 
       const filter = searchText && {

--- a/server/src/resolvers/Notification/mutation.ts
+++ b/server/src/resolvers/Notification/mutation.ts
@@ -1,5 +1,7 @@
 import { mutationField, nonNull, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 export const createNotification = mutationField('createNotification', {
   type: 'Notification',
 
@@ -10,6 +12,8 @@ export const createNotification = mutationField('createNotification', {
   },
 
   resolve: (parent, { token, device, os }, { prisma, userId }) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.notification.create({
       data: {
         token,

--- a/server/src/resolvers/Notification/query.ts
+++ b/server/src/resolvers/Notification/query.ts
@@ -1,8 +1,8 @@
-import { list, queryField, stringArg } from 'nexus';
+import { list, nonNull, queryField, stringArg } from 'nexus';
 
 export const notifications = queryField('notifications', {
   type: list('Notification'),
-  args: { userId: stringArg() },
+  args: { userId: nonNull(stringArg()) },
 
   resolve: (parent, { userId }, ctx) => {
     return ctx.prisma.notification.findMany({

--- a/server/src/resolvers/Report/mutation.ts
+++ b/server/src/resolvers/Report/mutation.ts
@@ -1,6 +1,8 @@
 import SendGridMail, { MailDataRequired } from '@sendgrid/mail';
 import { mutationField, nonNull, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
+
 const { SENDGRID_EMAIL } = process.env;
 
 export const createReport = mutationField('createReport', {
@@ -12,6 +14,9 @@ export const createReport = mutationField('createReport', {
   },
 
   resolve: async (_, { reportedUserId, report }, { prisma, request, userId }) => {
+    assert(userId, 'Not authorized.');
+    assert(SENDGRID_EMAIL, 'Missing sendgrid email address.');
+
     const msg: MailDataRequired = {
       to: 'hackatalk@gmail.com',
       from: SENDGRID_EMAIL,

--- a/server/src/resolvers/Report/query.ts
+++ b/server/src/resolvers/Report/query.ts
@@ -1,10 +1,10 @@
-import { list, queryField, stringArg } from 'nexus';
+import { list, nonNull, queryField, stringArg } from 'nexus';
 
 export const reports = queryField('reports', {
   type: list('Report'),
 
   args: {
-    userId: stringArg(),
+    userId: nonNull(stringArg()),
   },
 
   resolve: (_, { userId }, ctx) => {

--- a/server/src/resolvers/User/query.ts
+++ b/server/src/resolvers/User/query.ts
@@ -1,10 +1,11 @@
-import { queryField, stringArg } from 'nexus';
+import { nonNull, queryField, stringArg } from 'nexus';
 
+import { assert } from '../../utils/assert';
 import { relayToPrismaPagination } from '../../utils/pagination';
 
 export const user = queryField('user', {
   type: 'User',
-  args: { id: stringArg() },
+  args: { id: nonNull(stringArg()) },
   description: 'Fetch user profile',
 
   resolve: (parent, args, ctx) => {
@@ -48,7 +49,7 @@ export const userConnection = queryField((t) => {
         where: {
           ...filter,
           AND: [
-            { id: { not: userId } },
+            { id: { not: userId ?? undefined } },
           ],
           verified: true,
           deletedAt: null,
@@ -64,6 +65,8 @@ export const me = queryField('me', {
   description: 'Fetch current user profile when authenticated.',
 
   resolve: (parent, args, { prisma, userId }) => {
+    assert(userId, 'Not authorized.');
+
     return prisma.user.findUnique({
       where: {
         id: userId,

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -2,6 +2,7 @@ import { ApolloServer } from 'apollo-server-express';
 import { Http2Server } from 'http2';
 import SendGridMail from '@sendgrid/mail';
 import { applyMiddleware } from 'graphql-middleware';
+import { assert } from './utils/assert';
 import { createApp } from './app';
 import { createContext } from './context';
 import { createServer as createHttpServer } from 'http';
@@ -18,6 +19,7 @@ const schemaWithMiddleware = NODE_ENV === 'test'
     permissions,
   );
 
+assert(SENDGRID_API_KEY, 'Missing SENDGRID_API_KEY environment variable.');
 SendGridMail.setApiKey(SENDGRID_API_KEY);
 
 const createApolloServer = (): ApolloServer => new ApolloServer({

--- a/server/src/services/ChannelService.ts
+++ b/server/src/services/ChannelService.ts
@@ -1,6 +1,7 @@
 import { Channel, Membership, MembershipType } from '@prisma/client';
-import { T, always, andThen, cond, gt, lt, map, pipe, when } from 'ramda';
+import { andThen, cond, pipe } from 'ramda';
 
+import { assert } from '../utils/assert';
 import { prisma } from '../context';
 
 export const findExistingChannel = async (channelId: string): Promise<Channel> => {
@@ -8,12 +9,14 @@ export const findExistingChannel = async (channelId: string): Promise<Channel> =
     where: { id: channelId, deletedAt: null },
   });
 
+  assert(channel, 'Could not find the channel.');
+
   return channel;
 };
 
 export const findChannelWithUserIds = async (
   userIds: string[],
-): Promise<Channel> => {
+): Promise<Channel | undefined> => {
   const channels = await prisma.channel.findMany({
     include: {
       membership: {
@@ -37,7 +40,7 @@ export const findChannelWithUserIds = async (
 
 export const findPrivateChannelWithUserIds = async (
   userIds: string[],
-): Promise<Channel> => {
+): Promise<Channel | undefined> => {
   const channels = await prisma.channel.findMany({
     include: {
       membership: {

--- a/server/src/services/NotificationService.ts
+++ b/server/src/services/NotificationService.ts
@@ -28,8 +28,7 @@ export const sendPushNotification = async (
       },
     );
   } catch (e) {
-    console.warn(`Failed to send notification: ${e}`);
-    console.warn(e.response.data.errors);
+    throw new Error(`Failed to send notification: ${e}`);
   }
 };
 

--- a/server/src/utils/assert.ts
+++ b/server/src/utils/assert.ts
@@ -1,0 +1,11 @@
+/**
+ * Asserts an expression, and throws and error when failed.
+ * This function can be used for type-assertions too.
+ * @param shouldBeTruthy Expression to assert.
+ * @param message Error message to throw when assertion fails.
+ */
+export function assert<T>(shouldBeTruthy: T, message?: string): asserts shouldBeTruthy {
+  if (!shouldBeTruthy) {
+    throw new Error(message);
+  }
+}

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -1,4 +1,3 @@
-import { Context } from '../context';
 import NodeRSA from 'node-rsa';
 import axios from 'axios';
 import bcrypt from 'bcrypt';
@@ -34,10 +33,10 @@ interface Token {
   userId: string;
 }
 
-export function getUserId({ req }: {req: ReqI18n}): string {
+export function getUserId({ req }: {req: ReqI18n}): string | null {
   const Authorization = req?.get?.('Authorization');
 
-  if (!Authorization) return;
+  if (!Authorization) return null;
 
   const token = Authorization.replace('Bearer ', '');
   const verifiedToken = verify(token, APP_SECRET) as Token;
@@ -239,8 +238,8 @@ export const getPasswordResetHTML = (
   return rendered;
 };
 
-// eslint-disable-next-line
-export const getToken = (req: Request & any): string => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getToken = (req: Request & any): string | null => {
   const authHeader = req.get('Authorization');
 
   if (!authHeader) {

--- a/server/src/utils/azure.ts
+++ b/server/src/utils/azure.ts
@@ -1,5 +1,6 @@
 import AzureStorage, { BlobService } from 'azure-storage';
 
+import { assert } from './assert';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import stream from 'stream';
 
@@ -8,7 +9,7 @@ require('dotenv').config();
 
 const { STORAGE_ACCOUNT, STORAGE_KEY } = process.env;
 
-const blobService = STORAGE_ACCOUNT
+const blobService = (STORAGE_ACCOUNT && STORAGE_KEY)
   ? AzureStorage.createBlobService(STORAGE_ACCOUNT, STORAGE_KEY)
   : undefined;
 
@@ -18,6 +19,8 @@ export const uploadFileToAzureBlobFromStream = (
   destDir: string,
   container: string,
 ): Promise<BlobService.BlobResult> => {
+  assert(blobService, 'Azure Storage is not initialized.');
+
   return new Promise(function(resolve, reject) {
     stream.pipe(
       blobService.createWriteStreamToBlockBlob(container, `${destDir}${destFile}`, function(
@@ -42,6 +45,8 @@ export const uploadFileToAzureBlobFromFile = (
   destFile: string,
   destDir: string,
 ): Promise<BlobService.BlobResult> => {
+  assert(blobService, 'Azure Storage is not initialized.');
+
   return new Promise(function(resolve, reject) {
     blobService.createBlockBlobFromLocalFile(container, `${destDir}${destFile}`, file, function(
       error,
@@ -62,6 +67,8 @@ export const deleteFileFromAzureBlob = (
   destFile: string,
   destDir: string,
 ): Promise<boolean> => {
+  assert(blobService, 'Azure Storage is not initialized.');
+
   return new Promise(function(resolve, reject) {
     blobService.deleteBlobIfExists(destDir, destFile, function(
       error,
@@ -84,4 +91,8 @@ export const getURL = (
   sasToken?: string,
   primary?: boolean,
   snapshotId?: string,
-): string => blobService.getUrl(container, blob, sasToken, primary, snapshotId);
+): string => {
+  assert(blobService, 'Azure Storage is not initialized.');
+
+  return blobService.getUrl(container, blob, sasToken, primary, snapshotId);
+};

--- a/server/src/utils/filterNullProperties.ts
+++ b/server/src/utils/filterNullProperties.ts
@@ -1,0 +1,10 @@
+/**
+ * Create a new JavaScript object with all null properties replaced to undefined.
+ * @param obj target object.
+ */
+export function filterNullProperties<T>(obj: T): { [P in keyof T]: Exclude<T[P], null>} {
+  return Object.assign(
+    {},
+    ...Object.getOwnPropertyNames(obj).map((name) => ({ [name]: obj[name] === null ? undefined : obj[name] })),
+  );
+}

--- a/server/tests/e2e/queries/Channel.ts
+++ b/server/tests/e2e/queries/Channel.ts
@@ -1,6 +1,6 @@
 export const createChannel = /* GraphQL */`
   mutation createChannel(
-    $channel: ChannelCreateInput
+    $channel: ChannelCreateInput!
     $message: MessageCreateInput
   ) {
     createChannel(
@@ -24,7 +24,7 @@ export const createChannel = /* GraphQL */`
 `;
 
 export const channelQuery = /* GraphQL */`
-  query channel($channelId: String) {
+  query channel($channelId: String!) {
     channel(channelId: $channelId) {
       id
       channelType

--- a/server/tests/e2e/queries/User.ts
+++ b/server/tests/e2e/queries/User.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const signUpMutation = /* GraphQL */`
-  mutation signUp($user: UserCreateInput) {
+  mutation signUp($user: UserCreateInput!) {
     signUp(user: $user) {
       id
       name
@@ -66,7 +66,7 @@ export const signInWithApple = /* GraphQL */`
 `;
 
 export const updateProfileMutation = /* GraphQL */`
-  mutation updateProfile($user: UserUpdateInput) {
+  mutation updateProfile($user: UserUpdateInput!) {
     updateProfile(user: $user) {
       name
       gender

--- a/server/tests/integration/tests/user.test.ts
+++ b/server/tests/integration/tests/user.test.ts
@@ -131,7 +131,7 @@ describe('user resolvers', () => {
     const { mutate } = testServer(() => ({ userAPI }), userResolvers);
 
     const SIGN_UP = gql`
-      mutation signUp($user: UserCreateInput) {
+      mutation signUp($user: UserCreateInput!) {
         signUp(user: $user) {
           id
           name
@@ -141,7 +141,7 @@ describe('user resolvers', () => {
 
     const res = await mutate({
       mutation: SIGN_UP,
-      variables: { newUser },
+      variables: { user: newUser },
     });
 
     expect(res.errors).toBe(undefined);

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -22,7 +22,8 @@
     "outDir":"dist/",
     "baseUrl":"src/",
     "listFiles":false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true
   },
   "files": ["environment.d.ts"],
   "include": [


### PR DESCRIPTION
## Specify project
Server

## Description

### Summary
Enable `strict` option in `tsconfig.json` compiler options.

### Changes
- Add utility functions for type assertions & object manipulation.
    - `assert`: Typescript assertion function. This utility function can be used to narrowing types by throwing exception when unexpected type is detected. ([docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions))
    - `filterNullProperties`: Prisma client treats `null` and `undefined` differently. This utility function changes null properties of an js object to undefined. ([docs](https://www.prisma.io/docs/concepts/components/prisma-client/null-and-undefined))
- Mark some GraphQL args as `nonNull`. Because we were not using strict TS, there were some args not marked as nonNull by mistake.
- Fix type errors: Enabling TS strict mode revealed many type errors in our code base.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
