### PR TITLE
Remove expo-permissions from package.json due to deprecation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,6 @@
     "expo-linear-gradient": "~9.1.0",
     "expo-localization": "~10.1.0",
     "expo-notifications": "~0.11.5",
-    "expo-permissions": "~12.0.1",
     "expo-random": "~11.1.2",
     "expo-screen-orientation": "~3.1.0",
     "expo-splash-screen": "~0.10.2",

--- a/client/src/components/pages/__tests__/Message.test.tsx
+++ b/client/src/components/pages/__tests__/Message.test.tsx
@@ -41,10 +41,6 @@ jest.mock('@react-navigation/core', () => ({
   useRoute: () => mockRoute,
 }));
 
-jest.mock('expo-permissions', () => ({
-  askAsync: (): string => 'granted',
-}));
-
 jest.mock('expo-image-picker', () => ({
   launchCameraAsync: (): string => 'photo info',
   launchImageLibraryAsync: (): string => 'photo info',

--- a/client/src/components/pages/__tests__/ProfileUpdate.test.tsx
+++ b/client/src/components/pages/__tests__/ProfileUpdate.test.tsx
@@ -28,12 +28,6 @@ jest.mock('@expo/react-native-action-sheet', () => ({
   },
 }));
 
-jest.mock('expo-permissions', () => ({
-  askAsync: (): {status: string} => ({
-    status: 'granted',
-  }),
-}));
-
 jest.mock('expo-image-picker', () => ({
   launchCameraAsync: (): string => 'photo info',
   launchImageLibraryAsync: (): string => 'photo info',

--- a/client/src/utils/ImagePicker.ts
+++ b/client/src/utils/ImagePicker.ts
@@ -1,5 +1,4 @@
 import * as ImagePicker from 'expo-image-picker';
-import * as Permissions from 'expo-permissions';
 
 import {Platform} from 'react-native';
 
@@ -23,7 +22,7 @@ const photoOptions = {
 
 const requestPermissions = async (
   type: string,
-): Promise<Permissions.PermissionStatus> => {
+): Promise<ImagePicker.CameraPermissionResponse['status']> => {
   if (type === 'photo')
     if (Platform.OS !== 'web') {
       const {status} = await ImagePicker.requestMediaLibraryPermissionsAsync();
@@ -31,7 +30,7 @@ const requestPermissions = async (
       return status;
     }
 
-  const {status} = await Permissions.askAsync(Permissions.CAMERA);
+  const {status} = await ImagePicker.requestCameraPermissionsAsync();
 
   return status;
 };

--- a/client/src/utils/__tests__/ImagePicker.test.ts
+++ b/client/src/utils/__tests__/ImagePicker.test.ts
@@ -1,63 +1,69 @@
 import 'react-native';
 
+import * as ExImagePiacker from 'expo-image-picker';
 import * as ImagePicker from '../ImagePicker';
 
-import {askAsync} from 'expo-permissions';
-
-jest.mock('expo-permissions', () => ({
-  // @ts-ignore
-  ...jest.requireActual('expo-permissions'),
-  askAsync: jest.fn(),
-}));
-
 jest.mock('expo-image-picker', () => ({
+  ...jest.requireActual('expo-image-picker'),
   requestMediaLibraryPermissionsAsync: () => Promise.resolve({status: true}),
   launchCameraAsync: () => Promise.resolve(null),
   launchImageLibraryAsync: () => Promise.resolve(null),
 }));
 
 describe('ImagePicker interaction', () => {
-  it('launchCameraAsync should return photo info when permission is granted', async () => {
-    // @ts-ignore
-    askAsync.mockReturnValueOnce({
-      status: 'granted',
+  describe('Permission is granted', () => {
+    it('launchCameraAsync should return photo info when permission is granted', async () => {
+      jest
+        .spyOn(ExImagePiacker, 'requestCameraPermissionsAsync')
+        // @ts-ignore
+        .mockResolvedValue({
+          status: ExImagePiacker.PermissionStatus.GRANTED,
+        });
+
+      const result = await ImagePicker.launchCameraAsync();
+
+      expect(result).toBe(null);
     });
 
-    const result = await ImagePicker.launchCameraAsync();
+    it('launchImageLibraryAsync should return photo info when permission is granted', async () => {
+      jest
+        .spyOn(ExImagePiacker, 'requestCameraPermissionsAsync')
+        // @ts-ignore
+        .mockResolvedValue({
+          status: ExImagePiacker.PermissionStatus.GRANTED,
+        });
 
-    expect(result).toBe(null);
+      const result = await ImagePicker.launchImageLibraryAsync();
+
+      expect(result).toBe(null);
+    });
   });
 
-  it('launchImageLibraryAsync should return photo info when permission is granted', async () => {
-    // @ts-ignore
-    askAsync.mockReturnValueOnce({
-      status: 'granted',
+  describe('Permission is not granted', () => {
+    it('launchCameraAsync should not return photo info when permission is not granted', async () => {
+      jest
+        .spyOn(ExImagePiacker, 'requestCameraPermissionsAsync')
+        // @ts-ignore
+        .mockResolvedValue({
+          status: ExImagePiacker.PermissionStatus.DENIED,
+        });
+
+      const result = await ImagePicker.launchCameraAsync();
+
+      expect(result).toBe(null);
     });
 
-    const result = await ImagePicker.launchImageLibraryAsync();
+    it('launchImageLibraryAsync should not return photo info when permission is not granted', async () => {
+      jest
+        .spyOn(ExImagePiacker, 'requestCameraPermissionsAsync')
+        // @ts-ignore
+        .mockResolvedValue({
+          status: ExImagePiacker.PermissionStatus.DENIED,
+        });
 
-    expect(result).toBe(null);
-  });
+      const result = await ImagePicker.launchImageLibraryAsync();
 
-  it('launchCameraAsync should not return photo info when permission is not granted', async () => {
-    // @ts-ignore
-    askAsync.mockReturnValueOnce({
-      status: 'denied',
+      expect(result).toBe(null);
     });
-
-    const result = await ImagePicker.launchCameraAsync();
-
-    expect(result).toBe(null);
-  });
-
-  it('launchImageLibraryAsync should not return photo info when permission is not granted', async () => {
-    // @ts-ignore
-    askAsync.mockReturnValueOnce({
-      status: 'denied',
-    });
-
-    const result = await ImagePicker.launchImageLibraryAsync();
-
-    expect(result).toBe(null);
   });
 });

--- a/client/src/utils/noti.ts
+++ b/client/src/utils/noti.ts
@@ -1,5 +1,4 @@
 import * as Notifications from 'expo-notifications';
-import * as Permissions from 'expo-permissions';
 
 import Constants from 'expo-constants';
 import {Platform} from 'react-native';
@@ -10,14 +9,12 @@ export const registerForPushNotificationsAsync = async (): Promise<
   let token: string | undefined;
 
   if (Constants.isDevice) {
-    const {status: existingStatus} = await Permissions.getAsync(
-      Permissions.NOTIFICATIONS,
-    );
+    const {status: existingStatus} = await Notifications.getPermissionsAsync();
 
     let finalStatus = existingStatus;
 
     if (existingStatus !== 'granted') {
-      const {status} = await Permissions.askAsync(Permissions.NOTIFICATIONS);
+      const {status} = await Notifications.requestPermissionsAsync();
 
       finalStatus = status;
     }


### PR DESCRIPTION
## Specify project
Client

## Description

Remove expo-permissions from package.json due to deprecation.

![image](https://user-images.githubusercontent.com/27461460/114987450-21a85c00-9ed0-11eb-9e14-c6d4f21f623f.png)


## Tests

Fixed tests in `ImagePicker` util.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
