### PR TITLE
Fix Broken Message Layout

### DIFF
--- a/client/src/components/pages/Message.tsx
+++ b/client/src/components/pages/Message.tsx
@@ -234,13 +234,13 @@ const MessagesFragment: FC<MessageProp> = ({channelId, messages}) => {
   };
 
   const renderItem: ListRenderItem<typeof nodes[number]> = ({item, index}) => {
-    const nextItemDate = nodes[index + 1]?.createdAt;
+    const nextItemDate = nodes[index - 1]?.createdAt;
 
     return (
       <MessageListItem
         userId={user?.id}
         testID={`message-list-item${index}`}
-        prevItemSenderId={nodes[index - 1]?.sender?.id}
+        prevItemSenderId={nodes[index + 1]?.sender?.id}
         nextItemDate={
           typeof nextItemDate === 'string' ? nextItemDate : undefined
         }

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -37,7 +37,7 @@ const WrapperPeer = styled.View<{isSame: boolean}>`
   justify-content: flex-start;
   margin-left: 20px;
   margin-right: 8px;
-  margin-top: ${({isSame}): number => (isSame ? 8 : 20)}px;
+  margin-top: ${({isSame}) => (isSame ? '8px' : '20px')};
   width: 100%;
 `;
 


### PR DESCRIPTION
## Specify project
react-native

## Description
`Message` component had a rendering issue. The issue was caused by how `prevItemSenderId` and `nextItemDate` were calculated. `nodes` is an array of messages in **reverse-order**, so index of the next item is one **less** than the current item. This PR fixes the error.
```ts
const nextItemDate = nodes[index + 1]?.createdAt; // WRONG
const nextItemDate = nodes[index - 1]?.createdAt; // CORRECT
// Same applies to `prevItemSenderId`
```

#### Before
![image](https://user-images.githubusercontent.com/8978815/116020253-e87c9400-a613-11eb-8620-62fa073553cd.png)

#### After
![image](https://user-images.githubusercontent.com/8978815/116020219-da2e7800-a613-11eb-904a-8637e88cf845.png)


## Related Issues
N/A

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
