### PR TITLE
Make Text Message Selectable

### DIFF
--- a/client/src/components/uis/GiftedChat.tsx
+++ b/client/src/components/uis/GiftedChat.tsx
@@ -170,6 +170,7 @@ function Shared<T>(props: Props<T>): React.ReactElement {
           keyExtractor={keyExtractor}
           data={messages}
           renderItem={renderItem}
+          removeClippedSubviews={false}
           onEndReached={onEndReached}
           ListEmptyComponent={emptyItem}
           ListHeaderComponent={

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -231,7 +231,7 @@ const MessageListItem: FC<Props> = ({
                   </TouchableOpacity>
                 </StyledPhotoContainer>
               ) : (
-                <StyledPeerTextMessage>{text}</StyledPeerTextMessage>
+                <StyledPeerTextMessage selectable>{text}</StyledPeerTextMessage>
               )}
             </StyledTextPeerMessageContainer>
           </View>
@@ -261,7 +261,7 @@ const MessageListItem: FC<Props> = ({
             </TouchableOpacity>
           </StyledPhotoContainer>
         ) : (
-          <StyledMyTextMessage>{text}</StyledMyTextMessage>
+          <StyledMyTextMessage selectable>{text}</StyledMyTextMessage>
         )}
       </StyledMyMessage>
       <StyledTextDate>


### PR DESCRIPTION
## Specify project
react-native

## Description
Make texts in message bubbles selectable by users.

## Related Issues
There is a known issue where `<Text>` inside `<FlatList>` cannot be selectable.
It can be resolved by adding `removeClippedSubviews={false}` prop to `<FlatList>`.
https://github.com/facebook/react-native/issues/26264

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
