### PR TITLE
Fix the Friend Issue in Relay Store

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -163,7 +163,7 @@ type MessageEdge {
 scalar MessageType
 
 type Mutation {
-  signUp(user: UserCreateInput!, photoUpload: Upload): User!
+  signUp(photoUpload: Upload, user: UserCreateInput!): User!
   signInEmail(email: String!, password: String!): AuthPayload!
   signInWithFacebook(accessToken: String!): AuthPayload!
   signInWithApple(accessToken: String!): AuthPayload!
@@ -402,6 +402,9 @@ type User {
 
   """Check if the user is blocked by the user who have signed in."""
   hasBlocked: Boolean
+
+  """This user is a friend of the authenticated user."""
+  isFriend: Boolean
 }
 
 type UserConnection {
@@ -421,8 +424,6 @@ input UserCreateInput {
   password: String!
   name: String
   nickname: String
-  thumbURL: String
-  photoURL: String
   birthday: Date
   gender: Gender
   phone: String

--- a/client/src/__generated__/FriendAddMutation.graphql.ts
+++ b/client/src/__generated__/FriendAddMutation.graphql.ts
@@ -10,6 +10,7 @@ export type FriendAddMutationResponse = {
     readonly addFriend: {
         readonly friend: {
             readonly id: string;
+            readonly isFriend: boolean | null;
         } | null;
     } | null;
 };
@@ -27,6 +28,7 @@ mutation FriendAddMutation(
   addFriend(friendId: $friendId) {
     friend {
       id
+      isFriend
     }
   }
 }
@@ -69,6 +71,13 @@ v1 = [
             "kind": "ScalarField",
             "name": "id",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFriend",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -95,14 +104,14 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "b2878c3fa9f926c9ffa231ef1e328c4c",
+    "cacheID": "544c28c83204588b98cec8e076a7f9de",
     "id": null,
     "metadata": {},
     "name": "FriendAddMutation",
     "operationKind": "mutation",
-    "text": "mutation FriendAddMutation(\n  $friendId: String!\n) {\n  addFriend(friendId: $friendId) {\n    friend {\n      id\n    }\n  }\n}\n"
+    "text": "mutation FriendAddMutation(\n  $friendId: String!\n) {\n  addFriend(friendId: $friendId) {\n    friend {\n      id\n      isFriend\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = 'a0f15536b577ae75587a9ec980809a5d';
+(node as any).hash = 'e4eb66b7631419b65f07fa38c7eeb214';
 export default node;

--- a/client/src/__generated__/FriendDeleteMutation.graphql.ts
+++ b/client/src/__generated__/FriendDeleteMutation.graphql.ts
@@ -10,6 +10,7 @@ export type FriendDeleteMutationResponse = {
     readonly deleteFriend: {
         readonly friend: {
             readonly id: string;
+            readonly isFriend: boolean | null;
         } | null;
     } | null;
 };
@@ -27,6 +28,7 @@ mutation FriendDeleteMutation(
   deleteFriend(friendId: $friendId) {
     friend {
       id
+      isFriend
     }
   }
 }
@@ -69,6 +71,13 @@ v1 = [
             "kind": "ScalarField",
             "name": "id",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFriend",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -95,14 +104,14 @@ return {
     "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "e6824128ef490212bcc9b08bfa6ecca4",
+    "cacheID": "83a03bd58e54642b4ea7e6038a998cf6",
     "id": null,
     "metadata": {},
     "name": "FriendDeleteMutation",
     "operationKind": "mutation",
-    "text": "mutation FriendDeleteMutation(\n  $friendId: String!\n) {\n  deleteFriend(friendId: $friendId) {\n    friend {\n      id\n    }\n  }\n}\n"
+    "text": "mutation FriendDeleteMutation(\n  $friendId: String!\n) {\n  deleteFriend(friendId: $friendId) {\n    friend {\n      id\n      isFriend\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '176edfc666a319a4889313b91cc4bf44';
+(node as any).hash = '0d50b4385882035ea6d9551c1fc47657';
 export default node;

--- a/client/src/__generated__/FriendFriendsPaginationQuery.graphql.ts
+++ b/client/src/__generated__/FriendFriendsPaginationQuery.graphql.ts
@@ -53,6 +53,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 
 fragment UserListItem_user on User {
@@ -205,6 +206,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isFriend",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "isOnline",
                     "storageKey": null
                   },
@@ -261,12 +269,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0b5648fdb0d624a30ec8fe26d19d6d3a",
+    "cacheID": "ca4550c25d7752c62f794d6009df3d92",
     "id": null,
     "metadata": {},
     "name": "FriendFriendsPaginationQuery",
     "operationKind": "query",
-    "text": "query FriendFriendsPaginationQuery(\n  $after: String\n  $first: Int!\n  $searchText: String\n) {\n  ...MainFriend_friends_2HEEH6\n}\n\nfragment MainFriend_friends_2HEEH6 on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query FriendFriendsPaginationQuery(\n  $after: String\n  $first: Int!\n  $searchText: String\n) {\n  ...MainFriend_friends_2HEEH6\n}\n\nfragment MainFriend_friends_2HEEH6 on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/FriendsQuery.graphql.ts
+++ b/client/src/__generated__/FriendsQuery.graphql.ts
@@ -86,6 +86,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 
 fragment UserListItem_user on User {
@@ -249,6 +250,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isFriend",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "isOnline",
                     "storageKey": null
                   },
@@ -386,12 +394,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9b5919d240b2548ac3e4e442cbb8e4e0",
+    "cacheID": "659722a53e5cf950603508746034930d",
     "id": null,
     "metadata": {},
     "name": "FriendsQuery",
     "operationKind": "query",
-    "text": "query FriendsQuery(\n  $first: Int!\n  $after: String\n  $searchText: String\n) {\n  ...MainFriend_friends_2HEEH6\n  ...ChannelCreate_friends_2yyznZ\n}\n\nfragment ChannelCreate_friends_2yyznZ on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        nickname\n        thumbURL\n        photoURL\n        birthday\n        gender\n        phone\n        statusMessage\n        verified\n        lastSignedIn\n        isOnline\n        hasBlocked\n        createdAt\n        updatedAt\n        deletedAt\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment MainFriend_friends_2HEEH6 on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query FriendsQuery(\n  $first: Int!\n  $after: String\n  $searchText: String\n) {\n  ...MainFriend_friends_2HEEH6\n  ...ChannelCreate_friends_2yyznZ\n}\n\nfragment ChannelCreate_friends_2yyznZ on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        email\n        name\n        nickname\n        thumbURL\n        photoURL\n        birthday\n        gender\n        phone\n        statusMessage\n        verified\n        lastSignedIn\n        isOnline\n        hasBlocked\n        createdAt\n        updatedAt\n        deletedAt\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment MainFriend_friends_2HEEH6 on Query {\n  friends(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
+++ b/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
@@ -70,6 +70,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 */
 
@@ -221,6 +222,13 @@ return {
                 "kind": "ScalarField",
                 "name": "statusMessage",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFriend",
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -260,12 +268,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a2d986333aa36459efbf09013fac7716",
+    "cacheID": "4e12c618eb031c7c20a6d8d00c3e287c",
     "id": null,
     "metadata": {},
     "name": "MainStackNavigatorOnMessageSubscription",
     "operationKind": "subscription",
-    "text": "subscription MainStackNavigatorOnMessageSubscription {\n  onMessage {\n    id\n    imageUrls\n    channel {\n      id\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n"
+    "text": "subscription MainStackNavigatorOnMessageSubscription {\n  onMessage {\n    id\n    imageUrls\n    channel {\n      id\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessageListItemTestQuery.graphql.ts
+++ b/client/src/__generated__/MessageListItemTestQuery.graphql.ts
@@ -48,6 +48,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 */
 
@@ -200,6 +201,13 @@ return {
                 "kind": "ScalarField",
                 "name": "statusMessage",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isFriend",
+                "storageKey": null
               }
             ],
             "storageKey": null
@@ -210,12 +218,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e5d792a8ca9a91411c7a80d505e17db1",
+    "cacheID": "15cbd80b34796cddc574810b807baea1",
     "id": null,
     "metadata": {},
     "name": "MessageListItemTestQuery",
     "operationKind": "query",
-    "text": "query MessageListItemTestQuery {\n  myData: message(id: \"test-id\") {\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n"
+    "text": "query MessageListItemTestQuery {\n  myData: message(id: \"test-id\") {\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessagePaginationQuery.graphql.ts
+++ b/client/src/__generated__/MessagePaginationQuery.graphql.ts
@@ -80,6 +80,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 */
 
@@ -246,6 +247,13 @@ return {
                         "kind": "ScalarField",
                         "name": "statusMessage",
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFriend",
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -355,12 +363,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "68ef5a6451312a76847d5187f06e4cd0",
+    "cacheID": "61dcdc65e32b9d221cbe7a0587f27155",
     "id": null,
     "metadata": {},
     "name": "MessagePaginationQuery",
     "operationKind": "query",
-    "text": "query MessagePaginationQuery(\n  $after: String\n  $channelId: String!\n  $first: Int!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n"
+    "text": "query MessagePaginationQuery(\n  $after: String\n  $channelId: String!\n  $first: Int!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessagesQuery.graphql.ts
+++ b/client/src/__generated__/MessagesQuery.graphql.ts
@@ -80,6 +80,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 */
 
@@ -254,6 +255,13 @@ return {
                         "kind": "ScalarField",
                         "name": "statusMessage",
                         "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isFriend",
+                        "storageKey": null
                       }
                     ],
                     "storageKey": null
@@ -363,12 +371,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fb24811f13926b20a34dead7c6196f02",
+    "cacheID": "6e9722a274e6596db662555b22e5ccb5",
     "id": null,
     "metadata": {},
     "name": "MessagesQuery",
     "operationKind": "query",
-    "text": "query MessagesQuery(\n  $first: Int!\n  $after: String\n  $channelId: String!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n"
+    "text": "query MessagesQuery(\n  $first: Int!\n  $after: String\n  $channelId: String!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/ProfileModalTestQuery.graphql.ts
+++ b/client/src/__generated__/ProfileModalTestQuery.graphql.ts
@@ -31,6 +31,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 */
 
@@ -124,6 +125,13 @@ return {
             "kind": "ScalarField",
             "name": "statusMessage",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFriend",
+            "storageKey": null
           }
         ],
         "storageKey": "user(id:\"test-id\")"
@@ -131,12 +139,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "245bc16bb59c2de7400c37232a76892f",
+    "cacheID": "fbcce0820e8b7b4bea23d7c1f85df55b",
     "id": null,
     "metadata": {},
     "name": "ProfileModalTestQuery",
     "operationKind": "query",
-    "text": "query ProfileModalTestQuery {\n  myData: user(id: \"test-id\") {\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n"
+    "text": "query ProfileModalTestQuery {\n  myData: user(id: \"test-id\") {\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/ProfileModal_user.graphql.ts
+++ b/client/src/__generated__/ProfileModal_user.graphql.ts
@@ -11,6 +11,7 @@ export type ProfileModal_user = {
     readonly nickname: string | null;
     readonly hasBlocked: boolean | null;
     readonly statusMessage: string | null;
+    readonly isFriend: boolean | null;
     readonly " $refType": "ProfileModal_user";
 };
 export type ProfileModal_user$data = ProfileModal_user;
@@ -68,10 +69,17 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "statusMessage",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isFriend",
+      "storageKey": null
     }
   ],
   "type": "User",
   "abstractKey": null
 };
-(node as any).hash = 'b17dffee414a7016405304ea4a3eea02';
+(node as any).hash = '589f433fd2a1a3c2e632de6bc8024f36';
 export default node;

--- a/client/src/__generated__/SearchUsersQuery.graphql.ts
+++ b/client/src/__generated__/SearchUsersQuery.graphql.ts
@@ -35,6 +35,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 
 fragment SearchUserComponent_user_2yyznZ on Query {
@@ -200,6 +201,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isFriend",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "isOnline",
                     "storageKey": null
                   },
@@ -258,12 +266,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "46661c899e96ca6e2905c2b96d36b027",
+    "cacheID": "675d2dbb817a4ab1d9db23cba3b055b0",
     "id": null,
     "metadata": {},
     "name": "SearchUsersQuery",
     "operationKind": "query",
-    "text": "query SearchUsersQuery(\n  $after: String\n  $first: Int\n  $searchText: String\n) {\n  ...SearchUserComponent_user_2yyznZ\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n\nfragment SearchUserComponent_user_2yyznZ on Query {\n  users(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query SearchUsersQuery(\n  $after: String\n  $first: Int\n  $searchText: String\n) {\n  ...SearchUserComponent_user_2yyznZ\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n\nfragment SearchUserComponent_user_2yyznZ on Query {\n  users(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/UserBlockedUsersQuery.graphql.ts
+++ b/client/src/__generated__/UserBlockedUsersQuery.graphql.ts
@@ -34,6 +34,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 
 fragment UserListItem_user on User {
@@ -142,6 +143,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "isFriend",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "isOnline",
             "storageKey": null
           }
@@ -151,12 +159,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c562c517044916513e601b9f741b0344",
+    "cacheID": "7bd15cc4e160652eb15d970256188c5b",
     "id": null,
     "metadata": {},
     "name": "UserBlockedUsersQuery",
     "operationKind": "query",
-    "text": "query UserBlockedUsersQuery {\n  blockedUsers {\n    id\n    ...ProfileModal_user\n    ...UserListItem_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query UserBlockedUsersQuery {\n  blockedUsers {\n    id\n    ...ProfileModal_user\n    ...UserListItem_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/UserSignUpMutation.graphql.ts
+++ b/client/src/__generated__/UserSignUpMutation.graphql.ts
@@ -8,8 +8,6 @@ export type UserCreateInput = {
     password: string;
     name?: string | null;
     nickname?: string | null;
-    thumbURL?: string | null;
-    photoURL?: string | null;
     birthday?: unknown | null;
     gender?: unknown | null;
     phone?: string | null;

--- a/client/src/__generated__/UserUsersPaginationQuery.graphql.ts
+++ b/client/src/__generated__/UserUsersPaginationQuery.graphql.ts
@@ -35,6 +35,7 @@ fragment ProfileModal_user on User {
   nickname
   hasBlocked
   statusMessage
+  isFriend
 }
 
 fragment SearchUserComponent_user_2yyznZ on Query {
@@ -206,6 +207,13 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
+                    "name": "isFriend",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
                     "name": "isOnline",
                     "storageKey": null
                   },
@@ -264,12 +272,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c41cc838c0da2556c11bca95e351e73c",
+    "cacheID": "52736e6ed6cb481589e9f23587ca6b2e",
     "id": null,
     "metadata": {},
     "name": "UserUsersPaginationQuery",
     "operationKind": "query",
-    "text": "query UserUsersPaginationQuery(\n  $first: Int!\n  $after: String\n  $searchText: String\n) {\n  ...SearchUserComponent_user_2yyznZ\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n}\n\nfragment SearchUserComponent_user_2yyznZ on Query {\n  users(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query UserUsersPaginationQuery(\n  $first: Int!\n  $after: String\n  $searchText: String\n) {\n  ...SearchUserComponent_user_2yyznZ\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n\nfragment SearchUserComponent_user_2yyznZ on Query {\n  users(first: $first, after: $after, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        ...ProfileModal_user\n        ...UserListItem_user\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/components/navigations/MainStackNavigator/ProfileModal.tsx
+++ b/client/src/components/navigations/MainStackNavigator/ProfileModal.tsx
@@ -49,6 +49,7 @@ const fragment = graphql`
     nickname
     hasBlocked
     statusMessage
+    isFriend
   }
 `;
 
@@ -105,13 +106,6 @@ const StyledTextFriendAdded = styled.Text`
   padding: 4px;
 `;
 
-const StyledTextFriendAlreadyAdded = styled.Text`
-  color: ${({theme}) => theme.negative};
-  font-size: 12px;
-  background-color: ${({theme}) => theme.background};
-  padding: 4px;
-`;
-
 interface Styles {
   wrapper: StyleProp<ViewStyle>;
   viewBtn: StyleProp<ViewStyle>;
@@ -143,7 +137,15 @@ type ModalContentProps = {
 const ModalContent: FC<ModalContentProps> = ({modalState, hideModal}) => {
   const userData = useFragment(fragment, modalState.user);
 
-  const {id, name, nickname, statusMessage, photoURL, hasBlocked} = userData;
+  const {
+    id,
+    name,
+    nickname,
+    statusMessage,
+    photoURL,
+    hasBlocked,
+    isFriend,
+  } = userData;
 
   const [showFriendAddedMessage, setShowFriendAddedMessage] = useState<boolean>(
     false,
@@ -186,7 +188,7 @@ const ModalContent: FC<ModalContentProps> = ({modalState, hideModal}) => {
         const root = proxyStore.getRoot();
 
         const connectionRecord =
-          root && ConnectionHandler.getConnection(root, 'Friend_friends');
+          root && ConnectionHandler.getConnection(root, 'MainFriend_friends');
 
         const userProxy = proxyStore.get(id);
 
@@ -219,7 +221,7 @@ const ModalContent: FC<ModalContentProps> = ({modalState, hideModal}) => {
         const root = proxyStore.getRoot();
 
         const connectionRecord =
-          root && ConnectionHandler.getConnection(root, 'Friend_friends');
+          root && ConnectionHandler.getConnection(root, 'MainFriend_friends');
 
         if (connectionRecord)
           ConnectionHandler.deleteNode(connectionRecord, id);
@@ -415,10 +417,6 @@ const ModalContent: FC<ModalContentProps> = ({modalState, hideModal}) => {
       {showFriendAddedMessage ? (
         addFriendInFlight ? (
           <LoadingIndicator size="small" />
-        ) : modalState?.isFriend ? (
-          <StyledTextFriendAlreadyAdded testID="already-added-message">
-            {getString('FRIEND_ALREADY_ADDED')}
-          </StyledTextFriendAlreadyAdded>
         ) : (
           <StyledTextFriendAdded testID="added-message">
             {getString('FRIEND_ADDED')}
@@ -433,11 +431,11 @@ const ModalContent: FC<ModalContentProps> = ({modalState, hideModal}) => {
             <TouchableOpacity
               testID="touch-add-friend"
               activeOpacity={0.5}
-              onPress={modalState?.isFriend ? deleteFriend : addFriend}
+              onPress={isFriend ? deleteFriend : addFriend}
               style={styles.viewBtn}>
               <View style={styles.viewBtn}>
                 <StyledText testID="text-add-title">
-                  {modalState?.isFriend
+                  {isFriend
                     ? getString('DELETE_FRIEND')
                     : getString('ADD_FRIEND')}
                 </StyledText>

--- a/client/src/components/pages/BlockedUser.tsx
+++ b/client/src/components/pages/BlockedUser.tsx
@@ -40,7 +40,6 @@ const ContentContainer: FC = () => {
     const pressUserItem = (): void => {
       showModal({
         user: item,
-        isFriend: false,
         hideButtons: true,
       });
     };

--- a/client/src/components/pages/MainFriend.tsx
+++ b/client/src/components/pages/MainFriend.tsx
@@ -73,7 +73,6 @@ const FriendsFragment: FC<FriendsFragmentProps> = ({friendsKey}) => {
   const userListOnPress = (user: ProfileModal_user$key): void => {
     showModal({
       user,
-      isFriend: true,
     });
   };
 

--- a/client/src/components/pages/SearchUser.tsx
+++ b/client/src/components/pages/SearchUser.tsx
@@ -102,7 +102,6 @@ const UsersFragment: FC<UserProps> = ({user, searchArgs}) => {
     const pressUserItem = (): void => {
       showModal({
         user: item,
-        isFriend: false,
       });
     };
 

--- a/client/src/providers/ProfileModalProvider.tsx
+++ b/client/src/providers/ProfileModalProvider.tsx
@@ -11,8 +11,6 @@ export type ModalState =
       isVisible: true;
       /** Which user the profile modal describes */
       user: ProfileModal_user$key;
-      /** Is the profile user a friend of the current user? */
-      isFriend?: boolean;
       /** Callback function for delete button */
       onDeleteFriend?: () => void;
       /** Callback function for add friend button */

--- a/client/src/relay/queries/Friend.tsx
+++ b/client/src/relay/queries/Friend.tsx
@@ -13,6 +13,7 @@ export const addFriendMutation = graphql`
     addFriend(friendId: $friendId) {
       friend {
         id
+        isFriend
       }
     }
   }
@@ -23,6 +24,7 @@ export const deleteFriendMutation = graphql`
     deleteFriend(friendId: $friendId) {
       friend {
         id
+        isFriend
       }
     }
   }

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -529,6 +529,8 @@ export type User = {
   notifications?: Maybe<Array<Maybe<Notification>>>;
   /** Check if the user is blocked by the user who have signed in. */
   hasBlocked?: Maybe<Scalars['Boolean']>;
+  /** This user is a friend of the authenticated user. */
+  isFriend?: Maybe<Scalars['Boolean']>;
 };
 
 export type UserConnection = {
@@ -544,8 +546,6 @@ export type UserCreateInput = {
   password: Scalars['String'];
   name?: Maybe<Scalars['String']>;
   nickname?: Maybe<Scalars['String']>;
-  thumbURL?: Maybe<Scalars['String']>;
-  photoURL?: Maybe<Scalars['String']>;
   birthday?: Maybe<Scalars['Date']>;
   gender?: Maybe<Scalars['Gender']>;
   phone?: Maybe<Scalars['String']>;

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -47,6 +47,24 @@ export const User = objectType({
         return !!blockedUser;
       },
     });
+
+    t.boolean('isFriend', {
+      description: 'This user is a friend of the authenticated user.',
+      resolve: async ({id}, _args, {userId}) => {
+        assert(userId, 'Not authorized.');
+
+        const friendQueryResult = await prisma.friend.findUnique({
+          where: {
+            userId_friendId: {
+              userId,
+              friendId: id,
+            },
+          },
+        });
+
+        return !!friendQueryResult;
+      },
+    });
   },
 });
 


### PR DESCRIPTION
## Specify project
both

## Description
#### As Is
Pressing the add button from `ProfileModal` does not update Relay store properly.

#### To Be
- Server
    - Add `isFriend` field resolver to `User` type. `isFriend` is true when a user is a friend of the authenticated user.
- Client
    - Remove `isFriend` field from `ModalState` of `ProfileModalProvider` (use `isFriend` field from `User` object instead).
    - Fix a typo in connection name: `Friend_friends` -> `MainFriend_friends`
    - Remove "already added" message from `ProfileModal`, because the add button does not appear when the user is already a friend.

## Related Issues
N/A

## Tests
Fix `ProfileModal` tests to reflect changes in `ProfileModalProvider` state type.

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
