### PR TITLE
Bugfix/web image upload

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,11 +24,9 @@
     "lint:i18n": "eslint --fix --ext .json --format node_modules/eslint-plugin-i18n-json/formatter.js assets/langs/",
     "relay": "relay-compiler",
     "relay-watch": "yarn relay-compiler --watch",
-    "schema": "get-graphql-schema https://hackatalk.azurewebsites.net/graphql > schema.graphql",
-    "schema:local": "get-graphql-schema http://localhost:4000/graphql > schema.graphql",
+    "schema": "get-graphql-schema http://localhost:4000/graphql > schema.graphql",
     "codegen": "graphql-codegen --config codegen.yml",
-    "generate": "yarn schema && yarn codegen",
-    "generate:local": "yarn schema:local && yarn codegen",
+    "generate": "yarn schema:local && yarn codegen",
     "predeploy": "expo build:web",
     "deploy-hosting": "npm run predeploy && firebase deploy --only hosting"
   },

--- a/client/src/apis/upload.ts
+++ b/client/src/apis/upload.ts
@@ -10,7 +10,7 @@ export const uploadImageAsync = async (
   fileNamePrefix: string = '',
 ): Promise<Response> => {
   const fileName = uri.split('/').pop();
-  const fileType = mime.getType(uri) as string;
+  const fileType = mime.getType(uri);
   const data: FormData = new FormData();
   const token = await AsyncStorage.getItem('token');
 

--- a/client/src/components/pages/ProfileUpdate.tsx
+++ b/client/src/components/pages/ProfileUpdate.tsx
@@ -1,4 +1,4 @@
-import {Alert, Image, TouchableOpacity, View} from 'react-native';
+import {Alert, Image, Platform, TouchableOpacity, View} from 'react-native';
 import {
   BUTTON_INDEX_CANCEL,
   BUTTON_INDEX_LAUNCH_CAMERA,
@@ -30,7 +30,7 @@ import {resizePhotoToMaxDimensionsAndCompressAsPNG} from '../../utils/image';
 import {showAlertForError} from '../../utils/common';
 import {singleUpload} from '../../relay/queries/Upload';
 import styled from '@emotion/native';
-// import {uploadImageAsync} from '../../apis/upload';
+import {uploadImageAsync} from '../../apis/upload';
 import {useActionSheet} from '@expo/react-native-action-sheet';
 import {useAuthContext} from '../../providers/AuthProvider';
 
@@ -145,6 +145,25 @@ const Screen: FC = () => {
           const fileType = fileTypeMatch
             ? `image/${fileTypeMatch[1]}`
             : 'image';
+
+          if (Platform.OS === 'web') {
+            const response = await uploadImageAsync(
+              resizedImage.uri,
+              'profiles',
+              `${user?.id || fileName}`,
+            );
+
+            const {url} = JSON.parse(await response.text());
+
+            if (!url)
+              return Alert.alert(getString('ERROR'), getString('URL_IS_NULL'));
+
+            if (url) setProfilePath(url);
+
+            setIsUploading(false);
+
+            return;
+          }
 
           const file = new ReactNativeFile({
             uri: resizedImage.uri,

--- a/client/src/components/pages/ProfileUpdate.tsx
+++ b/client/src/components/pages/ProfileUpdate.tsx
@@ -22,6 +22,7 @@ import {meQuery, profileUpdate} from '../../relay/queries/User';
 
 import {ImagePickerResult} from 'expo-image-picker';
 import {ReactNativeFile} from 'apollo-upload-client';
+import {Uploadable} from 'relay-runtime';
 import type {UserMeQuery} from '../../__generated__/UserMeQuery.graphql';
 import type {UserUpdateProfileMutation} from '../../__generated__/UserUpdateProfileMutation.graphql';
 import {getString} from '../../../STRINGS';
@@ -149,16 +150,14 @@ const Screen: FC = () => {
             uri: resizedImage.uri,
             name: `${user?.id || fileName}`,
             type: fileType,
-          });
+          }) as unknown as Uploadable;
 
           commitUpload({
             variables: {
               file: null,
               dir: 'profiles',
             },
-            uploadables: {
-              file,
-            },
+            uploadables: {file},
             onCompleted: (response: UploadSingleUploadMutationResponse) => {
               const url = response.singleUpload;
 

--- a/client/src/components/pages/SignUp.tsx
+++ b/client/src/components/pages/SignUp.tsx
@@ -30,6 +30,7 @@ import {
 import {AuthStackNavigationProps} from '../navigations/AuthStackNavigator';
 import {ReactNativeFile} from 'extract-files';
 import StatusBar from '../uis/StatusBar';
+import {Uploadable} from 'relay-runtime';
 import {UserSignUpMutation} from '../../__generated__/UserSignUpMutation.graphql';
 import {UserVerifyEmailMutation} from '../../__generated__/UserVerifyEmailMutation.graphql';
 import {getString} from '../../../STRINGS';
@@ -180,7 +181,7 @@ const Page: FC = () => {
       });
 
       mutationConfig.uploadables = {
-        photoUpload: file,
+        photoUpload: file as unknown as Uploadable,
       };
     }
 

--- a/client/src/components/pages/SignUp.tsx
+++ b/client/src/components/pages/SignUp.tsx
@@ -232,39 +232,43 @@ const Page: FC = () => {
         keyboardVerticalOffset={100}>
         <ScrollView style={{alignSelf: 'stretch'}}>
           <ContentsWrapper>
-            <TouchableOpacity
-              testID="button-user-icon"
-              activeOpacity={0.5}
-              style={{
-                alignSelf: 'center',
-                marginBottom: 12,
-              }}
-              onPress={pressProfileImage}>
-              {!profilePath ? (
-                <View
-                  style={{
-                    width: 90,
-                    height: 90,
-                  }}>
-                  <Image style={{height: 80, width: 80}} source={IC_PROFILE} />
-                  <Image
+            {Platform.OS !== 'web' && (
+              <TouchableOpacity
+                testID="button-user-icon"
+                activeOpacity={0.5}
+                style={{
+                  alignSelf: 'center',
+                  marginBottom: 12,
+                }}
+                onPress={pressProfileImage}>
+                {!profilePath ? (
+                  <View
                     style={{
-                      position: 'absolute',
-                      bottom: 0,
-                      right: 0,
-                    }}
-                    source={IC_CAMERA}
+                      width: 90,
+                      height: 90,
+                    }}>
+                    <Image
+                      style={{height: 80, width: 80}}
+                      source={IC_PROFILE}
+                    />
+                    <Image
+                      style={{
+                        position: 'absolute',
+                        bottom: 0,
+                        right: 0,
+                      }}
+                      source={IC_CAMERA}
+                    />
+                  </View>
+                ) : (
+                  <ProfileImage
+                    testID="profile-image"
+                    resizeMode="cover"
+                    source={{uri: profilePath}}
                   />
-                </View>
-              ) : (
-                <ProfileImage
-                  testID="profile-image"
-                  resizeMode="cover"
-                  source={{uri: profilePath}}
-                />
-              )}
-            </TouchableOpacity>
-
+                )}
+              </TouchableOpacity>
+            )}
             <EditText
               testID="input-email"
               styles={{

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,7 +6,8 @@
     "emitDecoratorMetadata": true,
     "jsx": "react-native",
     "lib": [
-      "es2017"
+      "es2017",
+      "dom"
     ],
     "module": "es2015",
     "moduleResolution": "node",

--- a/server/README.md
+++ b/server/README.md
@@ -21,7 +21,7 @@ Setup environment
    DATABASE_URL="postgresql://<user>:<password>@<url>:5432/postgres?schema=<scheme>"
    ```
    > Note that you should change appropriate values in `user`, `password`, `url`, `scheme` fields. Or you can even use other database. More about [connection urls](https://www.prisma.io/docs/reference/database-connectors/connection-urls)
-3. Running `yarn local` will load `env` from `dotenv/.env`.
+3. Running `yarn start` will load `env` from `dotenv/.env`.
 
 ## Generate Prisma Client and Nexus
 ```

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,7 @@
   "repository": "https://github.com/dooboolab/hackatalk/server",
   "license": "MIT",
   "scripts": {
-    "local": "dotenv -e ./dotenv/.env -- ts-node-dev --respawn --transpile-only --files src/server.ts",
-    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
-    "start": "ts-node src/server.ts",
+    "start": "dotenv -e ./dotenv/.env -- ts-node-dev --respawn --transpile-only --files src/server.ts",
     "prod": "node dist/server",
     "clean": "rm -rf dist",
     "build": "npm -s run clean && npm -s run generate && tsc",


### PR DESCRIPTION
## Specify project
react-native

## Description

In `web`, [expo-image-picker](https://docs.expo.io/versions/latest/sdk/imagepicker/) returns the `base64` instead of file URI. Therefore, we need a different approach to upload files on the client-side for the `web` env.

Currently, `base64` is not handled in `graphql api` for file upload so I've switched to using `uploadImageAsync` for `web`.

* Remove profile upload in [SignUp] page since graphql query what `base64` file is not compatible as mentioned above.


![web upload](https://user-images.githubusercontent.com/27461460/119260189-a6437400-bc0c-11eb-9d23-8c8d2eb2f801.gif)


## Related Issues

https://github.com/expo/expo/issues/9984

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
