### PR TITLE
Show only peer user when only two users are in [Message]

### DIFF
--- a/client/src/components/navigations/MainStackNavigator/index.tsx
+++ b/client/src/components/navigations/MainStackNavigator/index.tsx
@@ -206,7 +206,7 @@ function MainStackNavigator(): ReactElement {
       <Stack.Screen
         name="Message"
         component={Message}
-        options={getSimpleHeader(getString('MESSAGE'), theme)}
+        options={getSimpleHeader('', theme)}
       />
       <Stack.Screen
         name="Settings"


### PR DESCRIPTION
## Specify project
React Native

## Description
![image](https://user-images.githubusercontent.com/27461460/119488010-049b5e80-bd95-11eb-9265-13a09bdbf5d9.png)

Show only a peer user in [Message] when there are only two users (including the user himself).


## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
