### PR TITLE
Customize loading view and attempt to fix android splash screen

### DIFF
--- a/client/app.config.ts
+++ b/client/app.config.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 
 import {version} from './package.json';
 
-const androidVersionCode = 21;
+const androidVersionCode = 22;
 
 export default {
   expo: {

--- a/client/app.config.ts
+++ b/client/app.config.ts
@@ -53,6 +53,9 @@ export default {
       },
     },
     android: {
+      splash: {
+        resizeMode: 'native',
+      },
       versionCode: androidVersionCode,
       userInterfaceStyle: 'dark',
       package: 'com.dooboolab.hackatalk',

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hackatalk",
   "private": true,
-  "version": "1.6.3",
+  "version": "1.6.4",
   "main": "node_modules/expo/AppEntry.js",
   "description": "Opensource chat app",
   "author": "dooboolab",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,9 +30,7 @@ Notifications.setNotificationHandler({
   }),
 });
 
-const preventAutoHide = async (): Promise<void> => {
-  await SplashScreen.preventAutoHideAsync();
-};
+SplashScreen.preventAutoHideAsync();
 
 const HackatalkThemeProvider: FC<{children: ReactElement}> = ({children}) => {
   const colorScheme = useColorScheme();
@@ -68,8 +66,7 @@ const HackatalkThemeProvider: FC<{children: ReactElement}> = ({children}) => {
   const [assets] = useAssets(Icons);
 
   useEffect(() => {
-    if (!assets) preventAutoHide();
-    else hideSplashScreenThenRegisterNotification();
+    if (assets) hideSplashScreenThenRegisterNotification();
   }, [assets]);
 
   if (!assets)

--- a/client/src/components/pages/__tests__/Message.test.tsx
+++ b/client/src/components/pages/__tests__/Message.test.tsx
@@ -17,6 +17,8 @@ import {MainStackParamList} from '../../navigations/MainStackNavigator';
 import Message from '../Message';
 import React from 'react';
 
+jest.mock('../../uis/CustomLoadingIndicator', () => 'test');
+
 const mockNavigation = createMockNavigation();
 
 const mockRoute: RouteProp<MainStackParamList, 'Message'> = {

--- a/client/src/components/uis/CustomLoadingIndicator.tsx
+++ b/client/src/components/uis/CustomLoadingIndicator.tsx
@@ -1,23 +1,71 @@
-import React, {FC} from 'react';
+import {Animated, Easing, ImageStyle, StyleProp, View} from 'react-native';
+import React, {FC, useEffect, useState} from 'react';
 
-import {LoadingIndicator} from 'dooboo-ui';
-import styled from '@emotion/native';
+import {IC_ICON} from '../../utils/Icons';
 
-const Container = styled.View`
-  flex: 1;
-  background-color: ${({theme}) => theme.background};
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-`;
+type Props = {
+  style?: StyleProp<ImageStyle>;
+};
 
-type Props = {};
+const CustomLoadingIndicator: FC<Props> = ({style}) => {
+  const [animation] = useState(new Animated.Value(0));
+  const inputRange = [0, 1];
+  const outputRange = [1.7, 1.3];
+  const scale = animation.interpolate({inputRange, outputRange});
 
-const CustomLoadingIndicator: FC<Props> = () => {
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(animation, {
+          toValue: 1,
+          duration: 300,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animation, {
+          toValue: 0,
+          duration: 500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animation, {
+          toValue: 1,
+          duration: 300,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animation, {
+          toValue: 0,
+          duration: 500,
+          easing: Easing.linear,
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  });
+
   return (
-    <Container>
-      <LoadingIndicator />
-    </Container>
+    <View
+      style={{
+        flex: 1,
+        alignSelf: 'stretch',
+        backgroundColor: '(0, 0, 0, 0)',
+
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}>
+      <Animated.Image
+        style={[
+          {
+            opacity: 0.75,
+            borderRadius: 28,
+            transform: [{scale}],
+          },
+          style,
+        ]}
+        source={IC_ICON}
+      />
+    </View>
   );
 };
 


### PR DESCRIPTION
## Specify project
React Native

## Description

Customize loading view with animation and attempt to fix android splash screen showing white screen at start.
* Reference: https://github.com/expo/expo/tree/master/packages/expo-splash-screen#native-resize-mode

## Related Issues

https://github.com/expo/expo/issues/9282

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
