### PR TITLE
Fix Multiple Device Self Message Issue

### DIFF
--- a/client/src/relay/updaters.tsx
+++ b/client/src/relay/updaters.tsx
@@ -39,7 +39,17 @@ function prependMessageToChannel(
     'Message',
   );
 
-  ConnectionHandler.insertEdgeBefore(messagesConnection, newMessageEdge);
+  // Insert new edge if the message is not already in connection.
+
+  const existingEdges = messagesConnection?.getLinkedRecords('edges') ?? [];
+
+  if (
+    !existingEdges.find(
+      (edge) =>
+        edge.getLinkedRecord('node')?.getDataID() === messageProxy.getDataID(),
+    )
+  )
+    ConnectionHandler.insertEdgeBefore(messagesConnection, newMessageEdge);
 }
 
 /**

--- a/server/src/resolvers/Message/subscription.ts
+++ b/server/src/resolvers/Message/subscription.ts
@@ -25,10 +25,7 @@ export const onMessage = subscriptionField('onMessage', {
         },
       });
 
-      const correctChannel = !!membership; // Message is sent to the auth user's channel.
-      const fromSelf = payload.senderId === userId; // Message is sent by the auth user.
-
-      return correctChannel && !fromSelf;
+      return !!membership; // Message is sent to the auth user's channel.
     },
   ),
   resolve: (payload) => {


### PR DESCRIPTION
## Specify project
both

## Description
#### As Is
When a user is signed in on multiple devices at the same time, messages sent from one device do not show up on other devices. This is because the subscription resolver filters out messages sent by the authenticated user.

#### To Be
Server: Do not filter messages from oneself.
Client: When handling `next` on client, check for duplicate message ID before appending message to the connection.

## Related Issues
N/A

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
