### PR TITLE
Add [deviceKey] Arg for Filtering Subscriptions

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -215,7 +215,7 @@ type Mutation {
 
   """Removes some users from [public] channel."""
   kickUsersFromChannel(channelId: String!, userIds: [String!]!): Channel
-  createMessage(channelId: String!, message: MessageCreateInput!): Message
+  createMessage(channelId: String!, message: MessageCreateInput!, deviceKey: String!): Message
   deleteMessage(id: String!): Message
   createBlockedUser(blockedUserId: String!): BlockedUser
   deleteBlockedUser(blockedUserId: String!): BlockedUser
@@ -374,7 +374,7 @@ type Report {
 type Subscription {
   userSignedIn: User
   userUpdated: User
-  onMessage: Message
+  onMessage(deviceKey: String!): Message
 }
 
 """The `Upload` scalar type represents a file upload."""

--- a/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
+++ b/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
@@ -4,7 +4,9 @@
 
 import { ConcreteRequest } from "relay-runtime";
 import { FragmentRefs } from "relay-runtime";
-export type MainStackNavigatorOnMessageSubscriptionVariables = {};
+export type MainStackNavigatorOnMessageSubscriptionVariables = {
+    deviceKey: string;
+};
 export type MainStackNavigatorOnMessageSubscriptionResponse = {
     readonly onMessage: {
         readonly id: string;
@@ -37,8 +39,10 @@ export type MainStackNavigatorOnMessageSubscription = {
 
 
 /*
-subscription MainStackNavigatorOnMessageSubscription {
-  onMessage {
+subscription MainStackNavigatorOnMessageSubscription(
+  $deviceKey: String!
+) {
+  onMessage(deviceKey: $deviceKey) {
     id
     imageUrls
     channel {
@@ -91,49 +95,63 @@ fragment ProfileModal_user on User {
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = {
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "deviceKey"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "deviceKey",
+    "variableName": "deviceKey"
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v1 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageUrls",
   "storageKey": null
 },
-v2 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "messageType",
   "storageKey": null
 },
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "text",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "fileUrls",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "Channel",
@@ -141,7 +159,7 @@ v6 = {
   "name": "channel",
   "plural": false,
   "selections": [
-    (v0/*: any*/),
+    (v2/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -150,26 +168,26 @@ v6 = {
       "name": "lastMessage",
       "plural": false,
       "selections": [
-        (v0/*: any*/),
         (v2/*: any*/),
-        (v3/*: any*/),
-        (v1/*: any*/),
         (v4/*: any*/),
-        (v5/*: any*/)
+        (v5/*: any*/),
+        (v3/*: any*/),
+        (v6/*: any*/),
+        (v7/*: any*/)
       ],
       "storageKey": null
     }
   ],
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -178,22 +196,22 @@ v8 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "MainStackNavigatorOnMessageSubscription",
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v1/*: any*/),
         "concreteType": "Message",
         "kind": "LinkedField",
         "name": "onMessage",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
-          (v1/*: any*/),
-          (v6/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -202,13 +220,13 @@ return {
             "name": "sender",
             "plural": false,
             "selections": [
-              (v0/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/)
+              (v2/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/)
             ],
             "storageKey": null
           },
-          (v5/*: any*/),
+          (v7/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
@@ -223,21 +241,21 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "MainStackNavigatorOnMessageSubscription",
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": (v1/*: any*/),
         "concreteType": "Message",
         "kind": "LinkedField",
         "name": "onMessage",
         "plural": false,
         "selections": [
-          (v0/*: any*/),
-          (v1/*: any*/),
-          (v6/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -246,9 +264,9 @@ return {
             "name": "sender",
             "plural": false,
             "selections": [
-              (v0/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/),
+              (v2/*: any*/),
+              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -287,10 +305,10 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/),
-          (v2/*: any*/),
-          (v3/*: any*/),
+          (v7/*: any*/),
           (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -304,14 +322,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "18658598b6d85ba73ad7ef4f5bc09637",
+    "cacheID": "0e1751d727db1f3c91debe575577e25b",
     "id": null,
     "metadata": {},
     "name": "MainStackNavigatorOnMessageSubscription",
     "operationKind": "subscription",
-    "text": "subscription MainStackNavigatorOnMessageSubscription {\n  onMessage {\n    id\n    imageUrls\n    channel {\n      id\n      lastMessage {\n        id\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "subscription MainStackNavigatorOnMessageSubscription(\n  $deviceKey: String!\n) {\n  onMessage(deviceKey: $deviceKey) {\n    id\n    imageUrls\n    channel {\n      id\n      lastMessage {\n        id\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();
-(node as any).hash = 'befdb0a2235749160b96a256ca4e03bc';
+(node as any).hash = '31048ba88c501348e582a1bd6ce29daa';
 export default node;

--- a/client/src/__generated__/MessageCreateMutation.graphql.ts
+++ b/client/src/__generated__/MessageCreateMutation.graphql.ts
@@ -12,6 +12,7 @@ export type MessageCreateInput = {
 export type MessageCreateMutationVariables = {
     channelId: string;
     message: MessageCreateInput;
+    deviceKey: string;
 };
 export type MessageCreateMutationResponse = {
     readonly createMessage: {
@@ -56,8 +57,9 @@ export type MessageCreateMutation = {
 mutation MessageCreateMutation(
   $channelId: String!
   $message: MessageCreateInput!
+  $deviceKey: String!
 ) {
-  createMessage(channelId: $channelId, message: $message) {
+  createMessage(channelId: $channelId, message: $message, deviceKey: $deviceKey) {
     id
     text
     messageType
@@ -91,61 +93,64 @@ mutation MessageCreateMutation(
 */
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "channelId"
-  },
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "message"
-  }
-],
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "channelId"
+},
 v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "deviceKey"
+},
+v2 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "message"
+},
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v2 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "text",
   "storageKey": null
 },
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "messageType",
   "storageKey": null
 },
-v4 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageUrls",
   "storageKey": null
 },
-v5 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "fileUrls",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = [
+v9 = [
   {
     "alias": null,
     "args": [
@@ -153,6 +158,11 @@ v7 = [
         "kind": "Variable",
         "name": "channelId",
         "variableName": "channelId"
+      },
+      {
+        "kind": "Variable",
+        "name": "deviceKey",
+        "variableName": "deviceKey"
       },
       {
         "kind": "Variable",
@@ -165,11 +175,11 @@ v7 = [
     "name": "createMessage",
     "plural": false,
     "selections": [
-      (v1/*: any*/),
-      (v2/*: any*/),
       (v3/*: any*/),
       (v4/*: any*/),
       (v5/*: any*/),
+      (v6/*: any*/),
+      (v7/*: any*/),
       {
         "alias": null,
         "args": null,
@@ -178,7 +188,7 @@ v7 = [
         "name": "sender",
         "plural": false,
         "selections": [
-          (v1/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       },
@@ -190,7 +200,7 @@ v7 = [
         "name": "channel",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -198,7 +208,7 @@ v7 = [
             "name": "channelType",
             "storageKey": null
           },
-          (v6/*: any*/),
+          (v8/*: any*/),
           {
             "alias": null,
             "args": [
@@ -221,7 +231,7 @@ v7 = [
                 "name": "user",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/),
+                  (v8/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -257,10 +267,10 @@ v7 = [
             "name": "lastMessage",
             "plural": false,
             "selections": [
-              (v3/*: any*/),
-              (v2/*: any*/),
-              (v4/*: any*/),
               (v5/*: any*/),
+              (v4/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -280,30 +290,38 @@ v7 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/),
+      (v2/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "MessageCreateMutation",
-    "selections": (v7/*: any*/),
+    "selections": (v9/*: any*/),
     "type": "Mutation",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v2/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Operation",
     "name": "MessageCreateMutation",
-    "selections": (v7/*: any*/)
+    "selections": (v9/*: any*/)
   },
   "params": {
-    "cacheID": "50fb9f8aa4d4f0d545d0eef76299bd80",
+    "cacheID": "8c6d2c5aa0c7f7f1da9297e14a067a68",
     "id": null,
     "metadata": {},
     "name": "MessageCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation MessageCreateMutation(\n  $channelId: String!\n  $message: MessageCreateInput!\n) {\n  createMessage(channelId: $channelId, message: $message) {\n    id\n    text\n    messageType\n    imageUrls\n    fileUrls\n    sender {\n      id\n    }\n    channel {\n      id\n      channelType\n      name\n      memberships(excludeMe: true) {\n        user {\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n      lastMessage {\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation MessageCreateMutation(\n  $channelId: String!\n  $message: MessageCreateInput!\n  $deviceKey: String!\n) {\n  createMessage(channelId: $channelId, message: $message, deviceKey: $deviceKey) {\n    id\n    text\n    messageType\n    imageUrls\n    fileUrls\n    sender {\n      id\n    }\n    channel {\n      id\n      channelType\n      name\n      memberships(excludeMe: true) {\n        user {\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n      lastMessage {\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n    }\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '2c875d97a923b922c04582e60fc4bb18';
+(node as any).hash = '9b92d316535633c66e53a01aeaad0f5c';
 export default node;

--- a/client/src/components/navigations/MainStackNavigator/index.tsx
+++ b/client/src/components/navigations/MainStackNavigator/index.tsx
@@ -30,6 +30,7 @@ import StatusBar from '../../uis/StatusBar';
 import {getString} from '../../../../STRINGS';
 import {onMessageUpdater} from '../../../relay/updaters';
 import {requestPermissionsAsync} from 'expo-ads-admob';
+import {useDeviceContext} from '../../../providers';
 import {useTheme} from 'dooboo-ui';
 
 export type MainStackParamList = {
@@ -80,8 +81,8 @@ function getSimpleHeader(
 }
 
 const onMessageSubscription = graphql`
-  subscription MainStackNavigatorOnMessageSubscription {
-    onMessage {
+  subscription MainStackNavigatorOnMessageSubscription($deviceKey: String!) {
+    onMessage(deviceKey: $deviceKey) {
       id
       imageUrls
       channel {
@@ -134,17 +135,19 @@ function MainStackNavigator(): ReactElement {
     return () => subscription.remove();
   }, [navigation]);
 
+  const {deviceKey} = useDeviceContext();
+
   const subscriptionConfig = useMemo<
     GraphQLSubscriptionConfig<MainStackNavigatorOnMessageSubscription>
   >(
     () => ({
-      variables: {},
+      variables: {deviceKey},
       subscription: onMessageSubscription,
       updater: (store) => {
         onMessageUpdater(store);
       },
     }),
-    [],
+    [deviceKey],
   );
 
   useSubscription(subscriptionConfig);

--- a/client/src/components/pages/Message.tsx
+++ b/client/src/components/pages/Message.tsx
@@ -59,6 +59,7 @@ import {showAlertForError} from '../../utils/common';
 import styled from '@emotion/native';
 import {uploadImageAsync} from '../../apis/upload';
 import {useAuthContext} from '../../providers/AuthProvider';
+import {useDeviceContext} from '../../providers';
 import {useProfileContext} from '../../providers/ProfileModalProvider';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 
@@ -155,6 +156,7 @@ const MessagesFragment: FC<MessageProp> = ({channelId, messages}) => {
   const [commitMessage] = useMutation<MessageCreateMutation>(createMessage);
 
   const {user} = useAuthContext();
+  const {deviceKey} = useDeviceContext();
 
   const onSubmit = (): void => {
     if (!textToSend) return;
@@ -163,6 +165,7 @@ const MessagesFragment: FC<MessageProp> = ({channelId, messages}) => {
       variables: {
         channelId,
         message: {text: textToSend},
+        deviceKey,
       },
       optimisticUpdater: (store) => {
         if (user) {
@@ -215,6 +218,7 @@ const MessagesFragment: FC<MessageProp> = ({channelId, messages}) => {
               messageType: 'photo',
               imageUrls: [url],
             },
+            deviceKey,
           },
           updater: (store) => {
             if (user) createMessageUpdater(store, channelId);

--- a/client/src/providers/DeviceProvider.tsx
+++ b/client/src/providers/DeviceProvider.tsx
@@ -3,9 +3,12 @@ import * as Device from 'expo-device';
 import React, {FC, useEffect, useState} from 'react';
 
 import createCtx from '../utils/createCtx';
+import {nanoid} from 'nanoid';
 
 interface Context {
   deviceType: Device.DeviceType;
+  /** Key for identifying each device on GraphQL server. */
+  deviceKey: string;
   setDeviceType: React.Dispatch<React.SetStateAction<Device.DeviceType>>;
 }
 
@@ -15,6 +18,8 @@ const DeviceProvider: FC = ({children}) => {
   const [deviceType, setDeviceType] = useState<Device.DeviceType>(
     Device.DeviceType.PHONE,
   );
+
+  const deviceKey = nanoid();
 
   useEffect(() => {
     let isMounted = true;
@@ -33,6 +38,7 @@ const DeviceProvider: FC = ({children}) => {
     <Provider
       value={{
         deviceType,
+        deviceKey,
         setDeviceType,
       }}>
       {children}

--- a/client/src/relay/queries/Message.tsx
+++ b/client/src/relay/queries/Message.tsx
@@ -4,8 +4,13 @@ export const createMessage = graphql`
   mutation MessageCreateMutation(
     $channelId: String!
     $message: MessageCreateInput!
+    $deviceKey: String!
   ) {
-    createMessage(channelId: $channelId, message: $message) {
+    createMessage(
+      channelId: $channelId
+      message: $message
+      deviceKey: $deviceKey
+    ) {
       id
       text
       messageType

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -325,6 +325,7 @@ export type MutationKickUsersFromChannelArgs = {
 export type MutationCreateMessageArgs = {
   channelId: Scalars['String'];
   message: MessageCreateInput;
+  deviceKey: Scalars['String'];
 };
 
 
@@ -494,6 +495,11 @@ export type Subscription = {
   userSignedIn?: Maybe<User>;
   userUpdated?: Maybe<User>;
   onMessage?: Maybe<Message>;
+};
+
+
+export type SubscriptionOnMessageArgs = {
+  deviceKey: Scalars['String'];
 };
 
 

--- a/server/src/resolvers/Message/mutation.ts
+++ b/server/src/resolvers/Message/mutation.ts
@@ -18,11 +18,12 @@ export const createMessage = mutationField('createMessage', {
         type: 'MessageCreateInput',
       }),
     ),
+    deviceKey: nonNull(stringArg()),
   },
 
   resolve: async (
     parent,
-    {channelId, message},
+    {channelId, message, deviceKey},
     {prisma, request, userId, pubsub},
   ) => {
     assert(userId, 'Not authorized.');
@@ -47,7 +48,10 @@ export const createMessage = mutationField('createMessage', {
       },
     });
 
-    pubsub.publish(ON_MESSAGE, created);
+    pubsub.publish(ON_MESSAGE, {
+      message: created,
+      deviceKey,
+    });
 
     await prisma.channel.update({
       data: {

--- a/server/tests/queries/Message.ts
+++ b/server/tests/queries/Message.ts
@@ -1,6 +1,14 @@
 export const createMessage = /* GraphQL */ `
-  mutation createMessage($channelId: String!, $message: MessageCreateInput!) {
-    createMessage(channelId: $channelId, message: $message) {
+  mutation createMessage(
+    $channelId: String!
+    $message: MessageCreateInput!
+    $deviceKey: String!
+  ) {
+    createMessage(
+      channelId: $channelId
+      message: $message
+      deviceKey: $deviceKey
+    ) {
       id
       text
     }

--- a/server/tests/resolvers/message.test.ts
+++ b/server/tests/resolvers/message.test.ts
@@ -115,6 +115,7 @@ describe('Resolver - Channel', () => {
       message: {
         text: 'hellooo',
       },
+      deviceKey: 'unique',
     };
 
     const response = await authClient.request(createMessage, variables);


### PR DESCRIPTION
## Specify project
both

## Description
Prevent sending `onMessage` subscription to the device from which a message is sent.
#### Server
- Add `deviceKey` arg to `onMessage` subscription
- Add `deviceKey` arg to `createMessage` mutation
- Filter pubsub when `deviceKey` matches between `onMessage` and `createMessage`
#### Client
- Add `deviceKey` property to `DeviceContext`.
- Initialize `deviceKey` with `nanoid()`.

## Related Issues
Beginning from #405 , `onMessage` subscription is not filtered by `userId`. This caused the issue of subscription firing back to the origin device.

## Tests
N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
