### PR TITLE
Bugfix logout history [Web]

### DIFF
--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -1,8 +1,4 @@
-import AuthNavigator, {
-  AuthStackNavigationProps,
-} from '../navigations/AuthStackNavigator';
 import {Button, DoobooTheme, useTheme} from 'dooboo-ui';
-import {CompositeNavigationProp, useNavigation} from '@react-navigation/core';
 import {Platform, SectionList, SectionListData} from 'react-native';
 import React, {FC, ReactElement} from 'react';
 import {SvgApple, SvgFacebook, SvgGoogle} from '../../utils/Icons';
@@ -12,12 +8,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {FontAwesome} from '@expo/vector-icons';
 import {MainStackNavigationProps} from '../navigations/MainStackNavigator';
 import type {NotificationDeleteNotificationMutation} from '../../__generated__/NotificationDeleteNotificationMutation.graphql';
-import {RootStackNavigationProps} from '../navigations/RootStackNavigator';
 import {deleteNotification} from '../../relay/queries/Notification';
 import {getString} from '../../../STRINGS';
-import {makeRedirectUri} from 'expo-auth-session';
 import styled from '@emotion/native';
 import {useAuthContext} from '../../providers/AuthProvider';
+import {useNavigation} from '@react-navigation/core';
 
 const Container = styled.SafeAreaView`
   flex: 1;

--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -1,6 +1,10 @@
+import AuthNavigator, {
+  AuthStackNavigationProps,
+} from '../navigations/AuthStackNavigator';
 import {Button, DoobooTheme, useTheme} from 'dooboo-ui';
+import {CompositeNavigationProp, useNavigation} from '@react-navigation/core';
+import {Platform, SectionList, SectionListData} from 'react-native';
 import React, {FC, ReactElement} from 'react';
-import {SectionList, SectionListData} from 'react-native';
 import {SvgApple, SvgFacebook, SvgGoogle} from '../../utils/Icons';
 import {UseMutationConfig, useMutation} from 'react-relay';
 
@@ -8,11 +12,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {FontAwesome} from '@expo/vector-icons';
 import {MainStackNavigationProps} from '../navigations/MainStackNavigator';
 import type {NotificationDeleteNotificationMutation} from '../../__generated__/NotificationDeleteNotificationMutation.graphql';
+import {RootStackNavigationProps} from '../navigations/RootStackNavigator';
 import {deleteNotification} from '../../relay/queries/Notification';
 import {getString} from '../../../STRINGS';
+import {makeRedirectUri} from 'expo-auth-session';
 import styled from '@emotion/native';
 import {useAuthContext} from '../../providers/AuthProvider';
-import {useNavigation} from '@react-navigation/core';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -61,6 +66,7 @@ const Settings: FC = () => {
 
   const {user, signOutAsync} = useAuthContext();
   const {theme} = useTheme();
+
   const navigation = useNavigation<MainStackNavigationProps<'Settings'>>();
 
   const [commitNotification] =
@@ -89,6 +95,8 @@ const Settings: FC = () => {
 
   const logout = async (): Promise<void> => {
     if (navigation) {
+      if (Platform.OS === 'web') history.go(0);
+
       AsyncStorage.removeItem('token');
 
       const pushToken = await AsyncStorage.getItem('push_token');


### PR DESCRIPTION
## Specify project
website

## Description
When connecting to the web, the URL does not change when logout of the settings page. And when you login again, you will be redirected to the settings page.

So this solution moves to the 0th place in history when logout


## Related Issues

change the url, when logout

## Tests

web logout, and login again

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.

[wehack2021]-[Cloud]