### PR TITLE
fix: Fix DATABASE_URL is incorrect

### DIFF
--- a/website/docs/server/installation.md
+++ b/website/docs/server/installation.md
@@ -60,7 +60,7 @@ We are using [Prisma](https://www.prisma.io) and [Nexus](https://nexus.js.org/do
         ```
       - Include `DATABASE_URL` (* necessary field)
          ```
-         DATABASE_URL="postgresql://<user>:<password>!@<url>:5432/<database>"
+         DATABASE_URL="postgresql://<user>:<password>@<url>:5432/<database>"
          ```
          > Note that you should change appropriate values in `user`, `password`, `url`, `database`, `scheme` fields. Or you can even use other databases. More about [connection urls](https://www.prisma.io/docs/reference/database-connectors/connection-urls)
       - Then run `yarn start` to start server with your local environment.


### PR DESCRIPTION
## Specify project
Website

## Description

There is error that DATABASE_URL setting is incorrect.
```
DATABASE_URL="postgresql://<user>:<password>!@<url>:5432/<database>"
``` 
must be

```
DATABASE_URL="postgresql://<user>:<password>@<url>:5432/<database>"
```

[Here is sources.](https://www.prisma.io/docs/getting-started/setup-prisma/start-from-scratch/relational-databases/connect-your-database-typescript-postgres/#connect-your-database)

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] Run `yarn lint && yarn tsc`
- [X] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [X] I am willing to follow-up on review comments in a timely manner.
