### PR TITLE
Bugfix url handling bug on logout [Web]

### DIFF
--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -61,7 +61,6 @@ const Settings: FC = () => {
 
   const {user, signOutAsync} = useAuthContext();
   const {theme} = useTheme();
-
   const navigation = useNavigation<MainStackNavigationProps<'Settings'>>();
 
   const [commitNotification] =

--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -1,8 +1,4 @@
-import AuthNavigator, {
-  AuthStackNavigationProps,
-} from '../navigations/AuthStackNavigator';
 import {Button, DoobooTheme, useTheme} from 'dooboo-ui';
-import {CompositeNavigationProp, useNavigation} from '@react-navigation/core';
 import {Platform, SectionList, SectionListData} from 'react-native';
 import React, {FC, ReactElement} from 'react';
 import {SvgApple, SvgFacebook, SvgGoogle} from '../../utils/Icons';
@@ -12,12 +8,11 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {FontAwesome} from '@expo/vector-icons';
 import {MainStackNavigationProps} from '../navigations/MainStackNavigator';
 import type {NotificationDeleteNotificationMutation} from '../../__generated__/NotificationDeleteNotificationMutation.graphql';
-import {RootStackNavigationProps} from '../navigations/RootStackNavigator';
 import {deleteNotification} from '../../relay/queries/Notification';
 import {getString} from '../../../STRINGS';
-import {makeRedirectUri} from 'expo-auth-session';
 import styled from '@emotion/native';
 import {useAuthContext} from '../../providers/AuthProvider';
+import {useNavigation} from '@react-navigation/core';
 
 const Container = styled.SafeAreaView`
   flex: 1;

--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -1,6 +1,10 @@
+import AuthNavigator, {
+  AuthStackNavigationProps,
+} from '../navigations/AuthStackNavigator';
 import {Button, DoobooTheme, useTheme} from 'dooboo-ui';
+import {CompositeNavigationProp, useNavigation} from '@react-navigation/core';
+import {Platform, SectionList, SectionListData} from 'react-native';
 import React, {FC, ReactElement} from 'react';
-import {SectionList, SectionListData} from 'react-native';
 import {SvgApple, SvgFacebook, SvgGoogle} from '../../utils/Icons';
 import {UseMutationConfig, useMutation} from 'react-relay';
 
@@ -8,11 +12,12 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {FontAwesome} from '@expo/vector-icons';
 import {MainStackNavigationProps} from '../navigations/MainStackNavigator';
 import type {NotificationDeleteNotificationMutation} from '../../__generated__/NotificationDeleteNotificationMutation.graphql';
+import {RootStackNavigationProps} from '../navigations/RootStackNavigator';
 import {deleteNotification} from '../../relay/queries/Notification';
 import {getString} from '../../../STRINGS';
+import {makeRedirectUri} from 'expo-auth-session';
 import styled from '@emotion/native';
 import {useAuthContext} from '../../providers/AuthProvider';
-import {useNavigation} from '@react-navigation/core';
 
 const Container = styled.SafeAreaView`
   flex: 1;
@@ -61,6 +66,7 @@ const Settings: FC = () => {
 
   const {user, signOutAsync} = useAuthContext();
   const {theme} = useTheme();
+
   const navigation = useNavigation<MainStackNavigationProps<'Settings'>>();
 
   const [commitNotification] =
@@ -89,6 +95,8 @@ const Settings: FC = () => {
 
   const logout = async (): Promise<void> => {
     if (navigation) {
+      if (Platform.OS === 'web') history.go(0);
+
       AsyncStorage.removeItem('token');
 
       const pushToken = await AsyncStorage.getItem('push_token');

--- a/client/src/components/pages/Settings.tsx
+++ b/client/src/components/pages/Settings.tsx
@@ -1,6 +1,6 @@
 import {Button, DoobooTheme, useTheme} from 'dooboo-ui';
-import {Platform, SectionList, SectionListData} from 'react-native';
 import React, {FC, ReactElement} from 'react';
+import {SectionList, SectionListData} from 'react-native';
 import {SvgApple, SvgFacebook, SvgGoogle} from '../../utils/Icons';
 import {UseMutationConfig, useMutation} from 'react-relay';
 
@@ -90,8 +90,6 @@ const Settings: FC = () => {
 
   const logout = async (): Promise<void> => {
     if (navigation) {
-      if (Platform.OS === 'web') history.go(0);
-
       AsyncStorage.removeItem('token');
 
       const pushToken = await AsyncStorage.getItem('push_token');

--- a/client/src/providers/AuthProvider.tsx
+++ b/client/src/providers/AuthProvider.tsx
@@ -59,6 +59,8 @@ function AuthProvider({children, initialAuthUser}: Props): React.ReactElement {
 
       disposeMeQuery();
 
+      setUser(null);
+
       resetRelayEnvironment();
     };
 


### PR DESCRIPTION
## Specify project
web

## Description

When connecting to the web, the URL does not change when logout of the settings page. And when you login again, you will be redirected to the settings page.

In order to handle url, the Navigation Container needs to give a proper linking prop, but AuthNavigatorOnly doesn't have a linking prop.

And signOutAsync does not initialize user information.

So, This solution initializes user information through `User(null)` in `signOutAsync()` of `AuthProvider`


## Related Issues

change the url and user information initialize, when logout

## Tests

web logout, and login again

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.

[wehack2021]-[Cloud]