### PR TITLE
Support the dooboo-ui Icon

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import {createRelayEnvironment} from './relay';
 import {getString} from '../STRINGS';
 import {registerForPushNotificationsAsync} from './utils/noti';
 import {useAssets} from 'expo-asset';
+import {useFonts} from 'expo-font';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -63,11 +64,15 @@ const HackatalkThemeProvider: FC<{children: ReactElement}> = ({children}) => {
 
   const [assets] = useAssets(Icons);
 
-  useEffect(() => {
-    if (assets) hideSplashScreenThenRegisterNotification();
-  }, [assets]);
+  const [dooboouiAssets] = useFonts({
+    IcoMoon: require('dooboo-ui/Icon/doobooui.ttf'),
+  });
 
-  if (!assets)
+  useEffect(() => {
+    if (assets && dooboouiAssets) hideSplashScreenThenRegisterNotification();
+  }, [assets, dooboouiAssets]);
+
+  if (!assets || !dooboouiAssets)
     return <AppLoading autoHideSplash={false} onError={console.warn} />;
 
   return (


### PR DESCRIPTION
## Specify project
_Is this related `react-native` project or `server` side or `website`?

#### `client`

## Description

To use `Icon` component from `dooboo-ui`, we need to load `doobooui.ttf` with `useFonts`.

## Related Issues

#### `N/A`

## Tests

I added the following tests:

#### `N/A`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.


[wehack2021]-[weRN dev life]