### PR TITLE
Add clickable Links/URL

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -79,6 +79,7 @@
     "react-native-get-random-values": "~1.7.0",
     "react-native-modalbox": "^2.0.2",
     "react-native-pager-view": "5.0.12",
+    "react-native-parsed-text": "^0.0.22",
     "react-native-reanimated": "~2.2.0",
     "react-native-safe-area-context": "3.2.0",
     "react-native-scalable-image": "^1.1.0",

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -1,5 +1,5 @@
 import {Linking, StyleSheet, TouchableOpacity, View} from 'react-native';
-import React, {FC} from 'react';
+import React, {FC, useMemo} from 'react';
 import {graphql, useFragment} from 'react-relay';
 
 import {IC_NO_IMAGE} from '../../utils/Icons';
@@ -7,9 +7,9 @@ import Image from 'react-native-scalable-image';
 import {MessageListItem_message$key} from '../../__generated__/MessageListItem_message.graphql';
 import ParsedText from 'react-native-parsed-text';
 import {ProfileModal_user$key} from '../../__generated__/ProfileModal_user.graphql';
+import {Theme} from '../../theme';
 import {User} from '../../types/graphql';
 import {getString} from '../../../STRINGS';
-import {light} from '../../theme';
 import moment from 'moment';
 import styled from '@emotion/native';
 import {useTheme} from 'dooboo-ui';
@@ -115,12 +115,14 @@ const StyledMyMessage = styled.View`
   border-radius: 3px;
 `;
 
-const styles = StyleSheet.create({
-  url: {
-    color: light.link,
-    textDecorationLine: 'underline',
-  },
-});
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+const makeStyles = (theme: Theme) =>
+  StyleSheet.create({
+    url: {
+      color: theme.link,
+      textDecorationLine: 'underline',
+    },
+  });
 
 interface ImageSenderProps {
   thumbURL?: string | null;
@@ -229,6 +231,7 @@ const MessageListItem: FC<Props> = ({
   userId,
 }) => {
   const {theme} = useTheme();
+  const styles = useMemo(() => makeStyles(theme), [theme]);
   const {id, sender, text, createdAt, imageUrls} = useFragment(fragment, item);
 
   const isPrevMessageSameUser = prevItemSender?.id === sender?.id;
@@ -286,7 +289,18 @@ const MessageListItem: FC<Props> = ({
                   </TouchableOpacity>
                 </StyledPhotoContainer>
               ) : (
-                <StyledPeerTextMessage selectable>{text}</StyledPeerTextMessage>
+                <StyledPeerTextMessage selectable>
+                  <ParsedText
+                    parse={[
+                      {
+                        type: 'url',
+                        onPress: handleUrlPress,
+                        style: styles.url,
+                      },
+                    ]}>
+                    {text}
+                  </ParsedText>
+                </StyledPeerTextMessage>
               )}
             </StyledTextPeerMessageContainer>
           </View>

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -9,6 +9,7 @@ import ParsedText from 'react-native-parsed-text';
 import {ProfileModal_user$key} from '../../__generated__/ProfileModal_user.graphql';
 import {User} from '../../types/graphql';
 import {getString} from '../../../STRINGS';
+import {light} from '../../theme';
 import moment from 'moment';
 import styled from '@emotion/native';
 import {useTheme} from 'dooboo-ui';
@@ -116,7 +117,7 @@ const StyledMyMessage = styled.View`
 
 const styles = StyleSheet.create({
   url: {
-    color: '#1E6EFA',
+    color: light.link,
     textDecorationLine: 'underline',
   },
 });

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -1,10 +1,11 @@
+import {Linking, StyleSheet, TouchableOpacity, View} from 'react-native';
 import React, {FC} from 'react';
-import {TouchableOpacity, View} from 'react-native';
 import {graphql, useFragment} from 'react-relay';
 
 import {IC_NO_IMAGE} from '../../utils/Icons';
 import Image from 'react-native-scalable-image';
 import {MessageListItem_message$key} from '../../__generated__/MessageListItem_message.graphql';
+import ParsedText from 'react-native-parsed-text';
 import {ProfileModal_user$key} from '../../__generated__/ProfileModal_user.graphql';
 import {User} from '../../types/graphql';
 import {getString} from '../../../STRINGS';
@@ -113,6 +114,13 @@ const StyledMyMessage = styled.View`
   border-radius: 3px;
 `;
 
+const styles = StyleSheet.create({
+  url: {
+    color: '#1E6EFA',
+    textDecorationLine: 'underline',
+  },
+});
+
 interface ImageSenderProps {
   thumbURL?: string | null;
   isSamePeerMsg: boolean;
@@ -161,6 +169,10 @@ const decorateDate = (createdAt: string): string => {
   if (diffHours >= 1) return `${date.format('A hh:mm')}`;
 
   return date.fromNow();
+};
+
+const handleUrlPress = (url: string): void => {
+  Linking.openURL(url);
 };
 
 const ImageSender: FC<ImageSenderProps> = ({thumbURL, isSamePeerMsg}) => {
@@ -301,7 +313,18 @@ const MessageListItem: FC<Props> = ({
             </TouchableOpacity>
           </StyledPhotoContainer>
         ) : (
-          <StyledMyTextMessage selectable>{text}</StyledMyTextMessage>
+          <StyledMyTextMessage selectable>
+            <ParsedText
+              parse={[
+                {
+                  type: 'url',
+                  onPress: handleUrlPress,
+                  style: styles.url,
+                },
+              ]}>
+              {text}
+            </ParsedText>
+          </StyledMyTextMessage>
         )}
       </StyledMyMessage>
       {showDate ? (

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -108,7 +108,7 @@ export const dark = {
   focused: '#ffffff',
   placeholderFocused: colors.paleBlue_10,
   socialBtn: colors.gray_05,
-  link: colors.paleBlue_05,
+  link: colors.blue_60,
   myMessageBackground: colors.deepDark,
   myMessageText: colors.light,
   peerMessageBackground: colors.paleBlue_05,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13762,7 +13762,7 @@ prompts@^2.0.1, prompts@^2.2.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.7.x:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -14061,6 +14061,13 @@ react-native-pager-view@5.0.12:
   version "5.0.12"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-5.0.12.tgz#5106735d944e7f876b006377ab6a18859bf7730c"
   integrity sha512-QmHUnQeP2qcxDofEOnKRmoUue0RaT55lhNJDfcQ1/SNuxif4Q2UyvDfqeItm1+toaE5tVnXqoreZh82FqUqnvw==
+
+react-native-parsed-text@^0.0.22:
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/react-native-parsed-text/-/react-native-parsed-text-0.0.22.tgz#a23c756eaa5d6724296814755085127f9072e5f5"
+  integrity sha512-hfD83RDXZf9Fvth3DowR7j65fMnlqM9PpxZBGWkzVcUTFtqe6/yPcIoIAgrJbKn6YmtzkivmhWE2MCE4JKBXrQ==
+  dependencies:
+    prop-types "^15.7.x"
 
 react-native-reanimated@~2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Specify project
#### `client`

## Description

#### Make Hackatalk to format URL texts as clickable links
<img src = "https://user-images.githubusercontent.com/53922851/129613911-7ae2b517-89de-45e8-a22b-798d94491b19.gif" width="320px">


## Related Issues
#### #434
## Tests

I added the following tests:

#### `N/A`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.

[wehack2021]-[Cloud]