### PR TITLE
[FindPw] Improve the coverage of `FindPw` page

### DIFF
--- a/client/src/components/pages/__tests__/FindPw.test.tsx
+++ b/client/src/components/pages/__tests__/FindPw.test.tsx
@@ -41,7 +41,7 @@ describe('[FindPw] interaction', () => {
   });
 
   describe('onFindPw', () => {
-    it('should show error text when the email is not validated', async () => {
+    it('should show error text when the email is not validated', () => {
       const component = createTestElement(<FindPw />);
       const screen = render(component);
       const textInput = screen.getByTestId('input-email');

--- a/client/src/components/pages/__tests__/FindPw.test.tsx
+++ b/client/src/components/pages/__tests__/FindPw.test.tsx
@@ -41,7 +41,7 @@ describe('[FindPw] interaction', () => {
   });
 
   describe('onFindPw', () => {
-    it('should show error text when the email is not validated', () => {
+    it('should show error text when the email is not validated', async () => {
       const component = createTestElement(<FindPw />);
       const screen = render(component);
       const textInput = screen.getByTestId('input-email');
@@ -55,6 +55,54 @@ describe('[FindPw] interaction', () => {
       const errorText = screen.getByText(getString('EMAIL_FORMAT_NOT_VALID'));
 
       expect(errorText).toBeTruthy();
+    });
+
+    it('should show error alert when user does not exists', async () => {
+      const mockEnvironment = createMockEnvironment();
+
+      mockEnvironment.mock.queueOperationResolver(
+        () => new Error(JSON.stringify({message: 'user does not exists'})),
+      );
+
+      const component = createTestElement(<FindPw />, {
+        environment: mockEnvironment,
+      });
+      const screen = render(component);
+      const textInput = screen.getByTestId('input-email');
+      const email = '11111@geoseong.net';
+
+      fireEvent.changeText(textInput, email);
+
+      const btnFindPw = screen.getByTestId('btn-find-pw');
+      const mockAlert = jest.spyOn(Alert, 'alert');
+
+      fireEvent.press(btnFindPw);
+
+      await waitFor(() => expect(mockAlert).toHaveBeenCalled());
+    });
+
+    it('should show error alert when email sent failed', async () => {
+      const mockEnvironment = createMockEnvironment();
+
+      mockEnvironment.mock.queueOperationResolver(
+        () => new Error(JSON.stringify({message: 'mail sent failed'})),
+      );
+
+      const component = createTestElement(<FindPw />, {
+        environment: mockEnvironment,
+      });
+      const screen = render(component);
+      const textInput = screen.getByTestId('input-email');
+      const email = 'hyochan@dooboolab.com';
+
+      fireEvent.changeText(textInput, email);
+
+      const btnFindPw = screen.getByTestId('btn-find-pw');
+      const mockAlert = jest.spyOn(Alert, 'alert');
+
+      fireEvent.press(btnFindPw);
+
+      await waitFor(() => expect(mockAlert).toHaveBeenCalled());
     });
 
     it('should call FindPw when button has clicked and navigate to SignIn', async () => {


### PR DESCRIPTION
## Specify project
`react-native`

## Description

Add test case of covering mutation's `onError` function

referred to [this "relay" documentation](https://relay.dev/docs/guides/testing-relay-components/#example-with-queueoperationresolver)

## Related Issues

none

## Tests

### Cases
- Should show error alert when user does not exists
- Should show error alert when email sent failed

### Coverage
**[Before]**
![image](https://user-images.githubusercontent.com/19166187/130347101-01a3d48a-ccf9-4e2b-a4ea-1976fc011911.png)

**[After]**
![image](https://user-images.githubusercontent.com/19166187/130347104-0e5c9f55-db65-49c7-9da2-5c10003628eb.png)


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
