### PR TITLE
Fix input-status of SignUp component

### DIFF
--- a/client/src/components/pages/SignUp.tsx
+++ b/client/src/components/pages/SignUp.tsx
@@ -372,6 +372,7 @@ const Page: FC = () => {
               onSubmitEditing={requestSignUp}
               textInputProps={{
                 multiline: true,
+                maxLength: 60,
               }}
             />
             <ButtonWrapper>


### PR DESCRIPTION
## Specify project
client

## Description

Related PR : https://github.com/dooboolab/hackatalk/pull/457
The "input-status" EditText of `SignUp` component should also has `textInputProps.maxLength=60` props. 

By the way, Writing status while signup process looks bit weird, so it might be needless.

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.

[wehack2021]-[cloud]