### PR TITLE
Remove an unnessary AuthProviderOnly navigator

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,13 +34,7 @@ Notifications.setNotificationHandler({
 SplashScreen.preventAutoHideAsync();
 
 const HackatalkThemeProvider: FC<{children: ReactElement}> = ({children}) => {
-  const hideSplashScreenThenRegisterNotification = async (): Promise<void> => {
-    try {
-      await SplashScreen.hideAsync();
-    } catch (err: any) {
-      // console.log('hide splash', err);
-    }
-
+  const registerNotification = async (): Promise<void> => {
     registerForPushNotificationsAsync()
       .then((pushToken) => {
         if (pushToken) {
@@ -69,7 +63,7 @@ const HackatalkThemeProvider: FC<{children: ReactElement}> = ({children}) => {
   });
 
   useEffect(() => {
-    if (assets && dooboouiAssets) hideSplashScreenThenRegisterNotification();
+    if (assets && dooboouiAssets) registerNotification();
   }, [assets, dooboouiAssets]);
 
   if (!assets || !dooboouiAssets)

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import * as Notifications from 'expo-notifications';
 import * as SplashScreen from 'expo-splash-screen';
 
-import React, {FC, ReactElement, ReactNode, Suspense, useEffect} from 'react';
+import React, {FC, ReactElement, ReactNode, useEffect} from 'react';
 import {dark, light} from './theme';
 
 import {ActionSheetProvider} from '@expo/react-native-action-sheet';
@@ -11,7 +11,6 @@ import {AppearanceProvider} from 'react-native-appearance';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {AuthProvider} from './providers/AuthProvider';
 import ComponentWrapper from './utils/ComponentWrapper';
-import CustomLoadingIndicator from './components/uis/CustomLoadingIndicator';
 import {DeviceProvider} from './providers/DeviceProvider';
 import Icons from './utils/Icons';
 import {RelayEnvironmentProvider} from 'react-relay';
@@ -104,7 +103,6 @@ const environment = createRelayEnvironment();
 const WrappedApp = new ComponentWrapper(RootNavigator)
   .wrap(ActionSheetProviderWithChildren, {})
   .wrap(AuthProvider, {})
-  .wrap(Suspense, {fallback: <CustomLoadingIndicator />})
   .wrap(RelayEnvironmentProvider, {environment})
   .wrap(DeviceProvider, {})
   .wrap(SnackbarProvider, {})

--- a/client/src/components/navigations/AuthStackNavigator.tsx
+++ b/client/src/components/navigations/AuthStackNavigator.tsx
@@ -1,4 +1,6 @@
-import React, {ReactElement} from 'react';
+import * as SplashScreen from 'expo-splash-screen';
+
+import React, {ReactElement, useCallback, useEffect} from 'react';
 import {
   StackNavigationProp,
   createStackNavigator,
@@ -39,6 +41,14 @@ const Stack = createStackNavigator<AuthStackParamList>();
 
 function AuthNavigator(): ReactElement {
   const {theme} = useTheme();
+
+  const hideSplashScreenAsync = useCallback(async () => {
+    await SplashScreen.hideAsync();
+  }, []);
+
+  useEffect(() => {
+    hideSplashScreenAsync();
+  }, [hideSplashScreenAsync]);
 
   return (
     <Stack.Navigator

--- a/client/src/components/navigations/MainStackNavigator/index.tsx
+++ b/client/src/components/navigations/MainStackNavigator/index.tsx
@@ -1,8 +1,9 @@
 import * as Notifications from 'expo-notifications';
+import * as SplashScreen from 'expo-splash-screen';
 
 import {CompositeNavigationProp, useNavigation} from '@react-navigation/native';
 import {Image, Platform, TouchableOpacity, View} from 'react-native';
-import React, {ReactElement, useEffect, useMemo} from 'react';
+import React, {ReactElement, useCallback, useEffect, useMemo} from 'react';
 import {
   StackNavigationOptions,
   StackNavigationProp,
@@ -118,6 +119,14 @@ const onMessageSubscription = graphql`
 function MainStackNavigator(): ReactElement {
   const {theme} = useTheme();
   const navigation = useNavigation<MainStackNavigationProps<'MainTab'>>();
+
+  const hideSplashScreenAsync = useCallback(async () => {
+    await SplashScreen.hideAsync();
+  }, []);
+
+  useEffect(() => {
+    hideSplashScreenAsync();
+  }, [hideSplashScreenAsync]);
 
   useEffect(() => {
     if (Platform.OS === 'android' || Platform.OS === 'ios')

--- a/client/src/components/navigations/RootStackNavigator.tsx
+++ b/client/src/components/navigations/RootStackNavigator.tsx
@@ -1,5 +1,3 @@
-import * as SplashScreen from 'expo-splash-screen';
-
 import AuthStack, {AuthStackParamList} from './AuthStackNavigator';
 import MainStack, {MainStackParamList} from './MainStackNavigator';
 import {
@@ -59,26 +57,7 @@ function RootNavigator({queryReference}: Props): React.ReactElement {
 
   const {user, setUser} = useAuthContext();
 
-  const hideSplash = async (): Promise<void> => {
-    try {
-      await SplashScreen.hideAsync();
-    } catch (err: any) {
-      // err
-    }
-  };
-
-  useEffect(() => {
-    if (!me) {
-      hideSplash();
-      setUser(null);
-
-      return;
-    }
-
-    hideSplash();
-
-    setUser(me);
-  }, [me, setUser]);
+  useEffect(() => (!me ? setUser(null) : setUser(me)), [me, setUser]);
 
   return (
     <SafeAreaProvider>
@@ -162,30 +141,6 @@ function RootNavigator({queryReference}: Props): React.ReactElement {
   );
 }
 
-function AuthNavigatorOnly(): React.ReactElement {
-  const {theme} = useTheme();
-
-  return (
-    <SafeAreaProvider>
-      <NavigationContainer
-        theme={{
-          colors: {
-            background: theme.background,
-            border: theme.background,
-            card: theme.background,
-            primary: theme.primary,
-            notification: theme.primary,
-            text: theme.primary,
-          },
-          dark: true,
-        }}
-      >
-        <AuthStack />
-      </NavigationContainer>
-    </SafeAreaProvider>
-  );
-}
-
 const RootNavigatorWrapper: FC = () => {
   const {user, loadMeQuery, meQueryReference} = useAuthContext();
   const {theme} = useTheme();
@@ -203,10 +158,8 @@ const RootNavigatorWrapper: FC = () => {
       }}
     >
       <Suspense fallback={<CustomLoadingIndicator />}>
-        {meQueryReference ? (
+        {meQueryReference && (
           <RootNavigator queryReference={meQueryReference} />
-        ) : (
-          <AuthNavigatorOnly />
         )}
       </Suspense>
     </View>

--- a/client/src/providers/AuthProvider.tsx
+++ b/client/src/providers/AuthProvider.tsx
@@ -3,6 +3,7 @@ import {
   AuthProviderMeQueryResponse,
   AuthProviderMeQueryVariables,
 } from '../__generated__/AuthProviderMeQuery.graphql';
+import type {Dispatch, SetStateAction} from 'react';
 import {
   PreloadedQuery,
   commitLocalUpdate,
@@ -18,7 +19,7 @@ import createCtx from '../utils/createCtx';
 
 export interface AuthContext {
   user: AuthProviderMeQueryResponse['me'] | null;
-  setUser: (value: AuthProviderMeQueryResponse['me'] | null) => void;
+  setUser: Dispatch<SetStateAction<AuthProviderMeQueryResponse['me'] | null>>;
   signOutAsync: () => void;
   meQueryReference?:
     | PreloadedQuery<AuthProviderMeQuery, Record<string, unknown>>


### PR DESCRIPTION
## Specify project

Client

## Description



## Related Issues

We don't need `AuthNavigatorOnly` navigator anymore since relay cache works perfectly. So I removed it and refactored minor things.

## Tests

I added the following tests:

N/A


## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
