### PR TITLE
patch: Filter user channels with memberships count

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -13,29 +13,22 @@ type AuthPayload {
   user: User!
 }
 
-enum AuthType {
-  email
-  facebook
-  google
-  apple
-}
-
 type BlockedUser {
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   user: User
   blockedUser: User
 }
 
 type Channel {
-  id: String!
-  channelType: ChannelType!
+  id: ID!
+  channelType: ChannelType
   name: String
   lastMessageId: String
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
 
   """Get latest message sent to the channel."""
   lastMessage: Message
@@ -94,12 +87,10 @@ representation of dates and times using the Gregorian calendar.
 """
 scalar Date
 
-scalar DateTime
-
 type Friend {
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   user: User
   friend: User
 }
@@ -109,9 +100,9 @@ scalar Gender
 type Membership {
   alertMode: AlertMode
   membershipType: MembershipType
-  isVisible: Boolean!
-  createdAt: DateTime
-  updatedAt: DateTime
+  isVisible: Boolean
+  createdAt: Date
+  updatedAt: Date
   user: User
   channel: Channel
 }
@@ -119,14 +110,14 @@ type Membership {
 scalar MembershipType
 
 type Message {
-  id: String!
+  id: ID!
   messageType: MessageType!
   text: String
   imageUrls: [String]
   fileUrls: [String]
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   channel: Channel
   sender: User
   replies: [Reply]
@@ -227,8 +218,7 @@ type Notification {
   token: String!
   device: String
   os: String
-  user: User!
-  createdAt: DateTime
+  createdAt: Date
 }
 
 """
@@ -258,7 +248,8 @@ type PageInfo {
 
 type Profile {
   socialId: String
-  authType: AuthType
+  authType: Auth
+  user: User
 }
 
 type Query {
@@ -347,27 +338,28 @@ type Query {
 }
 
 type Reaction {
-  id: Int!
+  id: ID!
   value: String!
 }
 
 type Reply {
-  id: Int!
+  id: ID!
   messageType: MessageType!
   text: String
-  imageUrls: [String!]!
-  fileUrls: [String!]!
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  imageUrls: [String]
+  fileUrls: [String]
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   sender: User!
 }
 
 type Report {
+  id: ID!
   report: String!
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   user: User
   reportedUser: User
 }
@@ -382,23 +374,23 @@ type Subscription {
 scalar Upload
 
 type User {
-  id: String!
+  id: ID!
   email: String
   name: String
   nickname: String
   thumbURL: String
   photoURL: String
-  birthday: DateTime
+  birthday: Date
   gender: Gender
   phone: String
   statusMessage: String
   verified: Boolean
-  lastSignedIn: DateTime
+  lastSignedIn: Date
   isOnline: Boolean
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date
   profile: Profile
-  createdAt: DateTime
-  updatedAt: DateTime
-  deletedAt: DateTime
   notifications: [Notification]
 
   """Check if the user is blocked by the user who have signed in."""

--- a/client/src/__generated__/AuthProviderMeQuery.graphql.ts
+++ b/client/src/__generated__/AuthProviderMeQuery.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type AuthProviderMeQueryVariables = {};
 export type AuthProviderMeQueryResponse = {
     readonly me: {
@@ -13,7 +12,7 @@ export type AuthProviderMeQueryResponse = {
         readonly verified: boolean | null;
         readonly profile: {
             readonly socialId: string | null;
-            readonly authType: AuthType | null;
+            readonly authType: unknown | null;
         } | null;
     } | null;
 };

--- a/client/src/__generated__/ChannelFindOrCreatePrivateChannelMutation.graphql.ts
+++ b/client/src/__generated__/ChannelFindOrCreatePrivateChannelMutation.graphql.ts
@@ -11,7 +11,7 @@ export type ChannelFindOrCreatePrivateChannelMutationResponse = {
     readonly findOrCreatePrivateChannel: {
         readonly id: string;
         readonly name: string | null;
-        readonly channelType: unknown;
+        readonly channelType: unknown | null;
     } | null;
 };
 export type ChannelFindOrCreatePrivateChannelMutation = {

--- a/client/src/__generated__/ChannelLeaveChannelMutation.graphql.ts
+++ b/client/src/__generated__/ChannelLeaveChannelMutation.graphql.ts
@@ -16,7 +16,7 @@ export type ChannelLeaveChannelMutationResponse = {
             readonly id: string;
         } | null;
         readonly alertMode: unknown | null;
-        readonly isVisible: boolean;
+        readonly isVisible: boolean | null;
     } | null;
 };
 export type ChannelLeaveChannelMutation = {

--- a/client/src/__generated__/MainChannelComponent_channel.graphql.ts
+++ b/client/src/__generated__/MainChannelComponent_channel.graphql.ts
@@ -11,7 +11,7 @@ export type MainChannelComponent_channel = {
             readonly cursor: string;
             readonly node: {
                 readonly id: string;
-                readonly channelType: unknown;
+                readonly channelType: unknown | null;
                 readonly name: string | null;
                 readonly memberships: ReadonlyArray<{
                     readonly user: {

--- a/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
+++ b/client/src/__generated__/MainStackNavigatorOnMessageSubscription.graphql.ts
@@ -98,6 +98,7 @@ fragment MessageListItem_message on Message {
     name
     nickname
     thumbURL
+    photoURL
     ...ProfileModal_user
   }
 }
@@ -376,12 +377,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3756096c39577bb06c52c9f84411340c",
+    "cacheID": "c99642bda9c3084912cc3ea0280cc12b",
     "id": null,
     "metadata": {},
     "name": "MainStackNavigatorOnMessageSubscription",
     "operationKind": "subscription",
-    "text": "subscription MainStackNavigatorOnMessageSubscription(\n  $deviceKey: String!\n) {\n  onMessage(deviceKey: $deviceKey) {\n    id\n    imageUrls\n    channel {\n      id\n      lastMessage {\n        id\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n      memberships(excludeMe: false) {\n        user {\n          id\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "subscription MainStackNavigatorOnMessageSubscription(\n  $deviceKey: String!\n) {\n  onMessage(deviceKey: $deviceKey) {\n    id\n    imageUrls\n    channel {\n      id\n      lastMessage {\n        id\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n      memberships(excludeMe: false) {\n        user {\n          id\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n    }\n    sender {\n      id\n      name\n      nickname\n    }\n    createdAt\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    photoURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessageCreateMutation.graphql.ts
+++ b/client/src/__generated__/MessageCreateMutation.graphql.ts
@@ -28,7 +28,7 @@ export type MessageCreateMutationResponse = {
         } | null;
         readonly channel: {
             readonly id: string;
-            readonly channelType: unknown;
+            readonly channelType: unknown | null;
             readonly name: string | null;
             readonly memberships: ReadonlyArray<{
                 readonly user: {
@@ -91,6 +91,7 @@ mutation MessageCreateMutation(
         imageUrls
         fileUrls
         createdAt
+        id
       }
     }
   }
@@ -113,189 +114,142 @@ v2 = {
   "kind": "LocalArgument",
   "name": "message"
 },
-v3 = {
+v3 = [
+  {
+    "kind": "Variable",
+    "name": "channelId",
+    "variableName": "channelId"
+  },
+  {
+    "kind": "Variable",
+    "name": "deviceKey",
+    "variableName": "deviceKey"
+  },
+  {
+    "kind": "Variable",
+    "name": "message",
+    "variableName": "message"
+  }
+],
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "text",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "messageType",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "imageUrls",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "fileUrls",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "createdAt",
   "storageKey": null
 },
-v9 = {
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "User",
+  "kind": "LinkedField",
+  "name": "sender",
+  "plural": false,
+  "selections": [
+    (v4/*: any*/)
+  ],
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "channelType",
+  "storageKey": null
+},
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = [
-  {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "channelId",
-        "variableName": "channelId"
-      },
-      {
-        "kind": "Variable",
-        "name": "deviceKey",
-        "variableName": "deviceKey"
-      },
-      {
-        "kind": "Variable",
-        "name": "message",
-        "variableName": "message"
-      }
-    ],
-    "concreteType": "Message",
-    "kind": "LinkedField",
-    "name": "createMessage",
-    "plural": false,
-    "selections": [
-      (v3/*: any*/),
-      (v4/*: any*/),
-      (v5/*: any*/),
-      (v6/*: any*/),
-      (v7/*: any*/),
-      (v8/*: any*/),
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "User",
-        "kind": "LinkedField",
-        "name": "sender",
-        "plural": false,
-        "selections": [
-          (v3/*: any*/)
-        ],
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "Channel",
-        "kind": "LinkedField",
-        "name": "channel",
-        "plural": false,
-        "selections": [
-          (v3/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "channelType",
-            "storageKey": null
-          },
-          (v9/*: any*/),
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "excludeMe",
-                "value": false
-              }
-            ],
-            "concreteType": "Membership",
-            "kind": "LinkedField",
-            "name": "memberships",
-            "plural": true,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "User",
-                "kind": "LinkedField",
-                "name": "user",
-                "plural": false,
-                "selections": [
-                  (v3/*: any*/),
-                  (v9/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "nickname",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "thumbURL",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "photoURL",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "memberships(excludeMe:false)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "Message",
-            "kind": "LinkedField",
-            "name": "lastMessage",
-            "plural": false,
-            "selections": [
-              (v5/*: any*/),
-              (v4/*: any*/),
-              (v6/*: any*/),
-              (v7/*: any*/),
-              (v8/*: any*/)
-            ],
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
-  }
-];
+v13 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "excludeMe",
+      "value": false
+    }
+  ],
+  "concreteType": "Membership",
+  "kind": "LinkedField",
+  "name": "memberships",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "User",
+      "kind": "LinkedField",
+      "name": "user",
+      "plural": false,
+      "selections": [
+        (v4/*: any*/),
+        (v12/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "nickname",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "thumbURL",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "photoURL",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "memberships(excludeMe:false)"
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -306,7 +260,57 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "MessageCreateMutation",
-    "selections": (v10/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "Message",
+        "kind": "LinkedField",
+        "name": "createMessage",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
+          (v10/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "channel",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Message",
+                "kind": "LinkedField",
+                "name": "lastMessage",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v5/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -319,15 +323,66 @@ return {
     ],
     "kind": "Operation",
     "name": "MessageCreateMutation",
-    "selections": (v10/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v3/*: any*/),
+        "concreteType": "Message",
+        "kind": "LinkedField",
+        "name": "createMessage",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          (v5/*: any*/),
+          (v6/*: any*/),
+          (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
+          (v10/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "channel",
+            "plural": false,
+            "selections": [
+              (v4/*: any*/),
+              (v11/*: any*/),
+              (v12/*: any*/),
+              (v13/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Message",
+                "kind": "LinkedField",
+                "name": "lastMessage",
+                "plural": false,
+                "selections": [
+                  (v6/*: any*/),
+                  (v5/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "5f928307c1ed715049301ebc956a2ada",
+    "cacheID": "bf0ad02629ed3114da35a35d5ec634d7",
     "id": null,
     "metadata": {},
     "name": "MessageCreateMutation",
     "operationKind": "mutation",
-    "text": "mutation MessageCreateMutation(\n  $channelId: String!\n  $message: MessageCreateInput!\n  $deviceKey: String!\n) {\n  createMessage(channelId: $channelId, message: $message, deviceKey: $deviceKey) {\n    id\n    text\n    messageType\n    imageUrls\n    fileUrls\n    createdAt\n    sender {\n      id\n    }\n    channel {\n      id\n      channelType\n      name\n      memberships(excludeMe: false) {\n        user {\n          id\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n      lastMessage {\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n      }\n    }\n  }\n}\n"
+    "text": "mutation MessageCreateMutation(\n  $channelId: String!\n  $message: MessageCreateInput!\n  $deviceKey: String!\n) {\n  createMessage(channelId: $channelId, message: $message, deviceKey: $deviceKey) {\n    id\n    text\n    messageType\n    imageUrls\n    fileUrls\n    createdAt\n    sender {\n      id\n    }\n    channel {\n      id\n      channelType\n      name\n      memberships(excludeMe: false) {\n        user {\n          id\n          name\n          nickname\n          thumbURL\n          photoURL\n        }\n      }\n      lastMessage {\n        messageType\n        text\n        imageUrls\n        fileUrls\n        createdAt\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessageListItemTestQuery.graphql.ts
+++ b/client/src/__generated__/MessageListItemTestQuery.graphql.ts
@@ -22,6 +22,7 @@ export type MessageListItemTestQuery = {
 query MessageListItemTestQuery {
   myData: message(id: "test-id") {
     ...MessageListItem_message
+    id
   }
 }
 
@@ -38,6 +39,7 @@ fragment MessageListItem_message on Message {
     name
     nickname
     thumbURL
+    photoURL
     ...ProfileModal_user
   }
 }
@@ -219,12 +221,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "15cbd80b34796cddc574810b807baea1",
+    "cacheID": "1e9ce3b5dafa14e87300feeefb00b632",
     "id": null,
     "metadata": {},
     "name": "MessageListItemTestQuery",
     "operationKind": "query",
-    "text": "query MessageListItemTestQuery {\n  myData: message(id: \"test-id\") {\n    ...MessageListItem_message\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "query MessageListItemTestQuery {\n  myData: message(id: \"test-id\") {\n    ...MessageListItem_message\n    id\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    photoURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessageListItem_message.graphql.ts
+++ b/client/src/__generated__/MessageListItem_message.graphql.ts
@@ -18,6 +18,7 @@ export type MessageListItem_message = {
         readonly name: string | null;
         readonly nickname: string | null;
         readonly thumbURL: string | null;
+        readonly photoURL: string | null;
         readonly " $fragmentRefs": FragmentRefs<"ProfileModal_user">;
     } | null;
     readonly " $refType": "MessageListItem_message";
@@ -118,6 +119,13 @@ return {
           "storageKey": null
         },
         {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "photoURL",
+          "storageKey": null
+        },
+        {
           "args": null,
           "kind": "FragmentSpread",
           "name": "ProfileModal_user"
@@ -130,5 +138,5 @@ return {
   "abstractKey": null
 };
 })();
-(node as any).hash = '05f3a3a95f03e49a39c3486538ad7bc2';
+(node as any).hash = '10bedc96c4bff58d435919c95263433b';
 export default node;

--- a/client/src/__generated__/MessagePaginationQuery.graphql.ts
+++ b/client/src/__generated__/MessagePaginationQuery.graphql.ts
@@ -71,6 +71,7 @@ fragment MessageListItem_message on Message {
     name
     nickname
     thumbURL
+    photoURL
     ...ProfileModal_user
   }
 }
@@ -365,12 +366,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "720758060f69bf2cc6bd27f80b12c765",
+    "cacheID": "c6f729384e859e115b8a5a80c76c7d1c",
     "id": null,
     "metadata": {},
     "name": "MessagePaginationQuery",
     "operationKind": "query",
-    "text": "query MessagePaginationQuery(\n  $after: String\n  $channelId: String!\n  $first: Int!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        text\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "query MessagePaginationQuery(\n  $after: String\n  $channelId: String!\n  $first: Int!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        text\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    photoURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/MessagesQuery.graphql.ts
+++ b/client/src/__generated__/MessagesQuery.graphql.ts
@@ -71,6 +71,7 @@ fragment MessageListItem_message on Message {
     name
     nickname
     thumbURL
+    photoURL
     ...ProfileModal_user
   }
 }
@@ -373,12 +374,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c9cf2878efe3c492733b3a7dfff4e230",
+    "cacheID": "89166a7261b6d342c76fd0f9c0f9b321",
     "id": null,
     "metadata": {},
     "name": "MessagesQuery",
     "operationKind": "query",
-    "text": "query MessagesQuery(\n  $first: Int!\n  $after: String\n  $channelId: String!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        text\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "query MessagesQuery(\n  $first: Int!\n  $after: String\n  $channelId: String!\n  $searchText: String\n) {\n  ...MessageComponent_message_WlZsr\n}\n\nfragment MessageComponent_message_WlZsr on Query {\n  messages(first: $first, after: $after, channelId: $channelId, searchText: $searchText) {\n    edges {\n      cursor\n      node {\n        id\n        imageUrls\n        text\n        sender {\n          id\n          name\n          nickname\n        }\n        createdAt\n        ...MessageListItem_message\n        __typename\n      }\n    }\n    pageInfo {\n      hasNextPage\n      hasPreviousPage\n      startCursor\n      endCursor\n    }\n  }\n}\n\nfragment MessageListItem_message on Message {\n  id\n  messageType\n  text\n  imageUrls\n  fileUrls\n  createdAt\n  updatedAt\n  sender {\n    id\n    name\n    nickname\n    thumbURL\n    photoURL\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/ProfileModalTestQuery.graphql.ts
+++ b/client/src/__generated__/ProfileModalTestQuery.graphql.ts
@@ -22,6 +22,7 @@ export type ProfileModalTestQuery = {
 query ProfileModalTestQuery {
   myData: user(id: "test-id") {
     ...ProfileModal_user
+    id
   }
 }
 
@@ -140,12 +141,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fbcce0820e8b7b4bea23d7c1f85df55b",
+    "cacheID": "5815d0b2fa821d35e57fbca69d4926d0",
     "id": null,
     "metadata": {},
     "name": "ProfileModalTestQuery",
     "operationKind": "query",
-    "text": "query ProfileModalTestQuery {\n  myData: user(id: \"test-id\") {\n    ...ProfileModal_user\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
+    "text": "query ProfileModalTestQuery {\n  myData: user(id: \"test-id\") {\n    ...ProfileModal_user\n    id\n  }\n}\n\nfragment ProfileModal_user on User {\n  id\n  photoURL\n  name\n  nickname\n  hasBlocked\n  statusMessage\n  isFriend\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/ReportCreateReportMutation.graphql.ts
+++ b/client/src/__generated__/ReportCreateReportMutation.graphql.ts
@@ -27,6 +27,7 @@ mutation ReportCreateReportMutation(
 ) {
   createReport(reportedUserId: $reportedUserId, report: $report) {
     report
+    id
   }
 }
 */
@@ -44,35 +45,23 @@ v1 = {
 },
 v2 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "report",
-        "variableName": "report"
-      },
-      {
-        "kind": "Variable",
-        "name": "reportedUserId",
-        "variableName": "reportedUserId"
-      }
-    ],
-    "concreteType": "Report",
-    "kind": "LinkedField",
-    "name": "createReport",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "report",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "report",
+    "variableName": "report"
+  },
+  {
+    "kind": "Variable",
+    "name": "reportedUserId",
+    "variableName": "reportedUserId"
   }
-];
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "report",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -82,7 +71,20 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "ReportCreateReportMutation",
-    "selections": (v2/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "Report",
+        "kind": "LinkedField",
+        "name": "createReport",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -94,15 +96,35 @@ return {
     ],
     "kind": "Operation",
     "name": "ReportCreateReportMutation",
-    "selections": (v2/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v2/*: any*/),
+        "concreteType": "Report",
+        "kind": "LinkedField",
+        "name": "createReport",
+        "plural": false,
+        "selections": [
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "9cad1f04016a1a6e843b68d8be6d4190",
+    "cacheID": "98ce154bd8dd3b281f5fc7e8229b8090",
     "id": null,
     "metadata": {},
     "name": "ReportCreateReportMutation",
     "operationKind": "mutation",
-    "text": "mutation ReportCreateReportMutation(\n  $reportedUserId: String!\n  $report: String!\n) {\n  createReport(reportedUserId: $reportedUserId, report: $report) {\n    report\n  }\n}\n"
+    "text": "mutation ReportCreateReportMutation(\n  $reportedUserId: String!\n  $report: String!\n) {\n  createReport(reportedUserId: $reportedUserId, report: $report) {\n    report\n    id\n  }\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/UserFacebookSignInMutation.graphql.ts
+++ b/client/src/__generated__/UserFacebookSignInMutation.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type UserFacebookSignInMutationVariables = {
     accessToken: string;
 };
@@ -18,7 +17,7 @@ export type UserFacebookSignInMutationResponse = {
             readonly photoURL: string | null;
             readonly verified: boolean | null;
             readonly profile: {
-                readonly authType: AuthType | null;
+                readonly authType: unknown | null;
             } | null;
         };
     };

--- a/client/src/__generated__/UserGoogleSignInMutation.graphql.ts
+++ b/client/src/__generated__/UserGoogleSignInMutation.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type UserGoogleSignInMutationVariables = {
     accessToken: string;
 };
@@ -18,7 +17,7 @@ export type UserGoogleSignInMutationResponse = {
             readonly photoURL: string | null;
             readonly verified: boolean | null;
             readonly profile: {
-                readonly authType: AuthType | null;
+                readonly authType: unknown | null;
             } | null;
         };
     };

--- a/client/src/__generated__/UserListItemTestQuery.graphql.ts
+++ b/client/src/__generated__/UserListItemTestQuery.graphql.ts
@@ -22,6 +22,7 @@ export type UserListItemTestQuery = {
 query UserListItemTestQuery {
   myData: user(id: "test-id") {
     ...UserListItem_user
+    id
   }
 }
 
@@ -140,12 +141,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a0056f27a643459dd64cec949ac6cc56",
+    "cacheID": "abfc66970a4cb1f1a8f8591dd3f2adbd",
     "id": null,
     "metadata": {},
     "name": "UserListItemTestQuery",
     "operationKind": "query",
-    "text": "query UserListItemTestQuery {\n  myData: user(id: \"test-id\") {\n    ...UserListItem_user\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
+    "text": "query UserListItemTestQuery {\n  myData: user(id: \"test-id\") {\n    ...UserListItem_user\n    id\n  }\n}\n\nfragment UserListItem_user on User {\n  id\n  photoURL\n  nickname\n  name\n  statusMessage\n  isOnline\n  hasBlocked\n}\n"
   }
 };
 })();

--- a/client/src/__generated__/UserMeQuery.graphql.ts
+++ b/client/src/__generated__/UserMeQuery.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type UserMeQueryVariables = {};
 export type UserMeQueryResponse = {
     readonly me: {
@@ -17,7 +16,7 @@ export type UserMeQueryResponse = {
         readonly photoURL: string | null;
         readonly thumbURL: string | null;
         readonly profile: {
-            readonly authType: AuthType | null;
+            readonly authType: unknown | null;
         } | null;
     } | null;
 };

--- a/client/src/__generated__/UserSignInAppleMutation.graphql.ts
+++ b/client/src/__generated__/UserSignInAppleMutation.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type UserSignInAppleMutationVariables = {
     accessToken: string;
 };
@@ -18,7 +17,7 @@ export type UserSignInAppleMutationResponse = {
             readonly photoURL: string | null;
             readonly verified: boolean | null;
             readonly profile: {
-                readonly authType: AuthType | null;
+                readonly authType: unknown | null;
             } | null;
         };
     };

--- a/client/src/__generated__/UserSignInEmailMutation.graphql.ts
+++ b/client/src/__generated__/UserSignInEmailMutation.graphql.ts
@@ -4,7 +4,6 @@
 
 import { ConcreteRequest } from "relay-runtime";
 
-export type AuthType = "apple" | "email" | "facebook" | "google";
 export type UserSignInEmailMutationVariables = {
     email: string;
     password: string;
@@ -19,7 +18,7 @@ export type UserSignInEmailMutationResponse = {
             readonly photoURL: string | null;
             readonly verified: boolean | null;
             readonly profile: {
-                readonly authType: AuthType | null;
+                readonly authType: unknown | null;
             } | null;
         };
     };

--- a/client/src/components/pages/SignIn/SocialSignInButton.tsx
+++ b/client/src/components/pages/SignIn/SocialSignInButton.tsx
@@ -3,7 +3,6 @@ import * as Config from '../../../../config';
 import * as WebBrowser from 'expo-web-browser';
 
 import {Alert, Platform, View} from 'react-native';
-import {AuthType, User} from '../../../types/graphql';
 import {Button, useTheme} from 'dooboo-ui';
 import React, {FC, ReactElement, useEffect, useState} from 'react';
 import type {
@@ -20,6 +19,7 @@ import {
 } from '../../../relay/queries/User';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import {User} from '../../../types/graphql';
 import {css} from '@emotion/native';
 import {getString} from '../../../../STRINGS';
 import {showAlertForError} from '../../../utils/common';
@@ -28,6 +28,8 @@ import {useMutation} from 'react-relay';
 const {facebookAppId, googleWebClientId} = Config;
 
 WebBrowser.maybeCompleteAuthSession();
+
+type AuthType = 'google' | 'apple' | 'facebook' | 'emails';
 
 interface Props {
   svgIcon: ReactElement;

--- a/client/src/components/uis/ChannelListItem.tsx
+++ b/client/src/components/uis/ChannelListItem.tsx
@@ -193,8 +193,6 @@ function ChannelListItem(props: Props): React.ReactElement {
   const {user} = useAuthContext();
 
   if (channelType !== 'public') {
-    console.log('memberships', memberships);
-
     const users = calculateUsers(memberships, user?.id, channelType);
 
     const photoURLs = calculatePhotoUrls(users);

--- a/client/src/components/uis/ChannelListItem.tsx
+++ b/client/src/components/uis/ChannelListItem.tsx
@@ -193,7 +193,10 @@ function ChannelListItem(props: Props): React.ReactElement {
   const {user} = useAuthContext();
 
   if (channelType !== 'public') {
+    console.log('memberships', memberships);
+
     const users = calculateUsers(memberships, user?.id, channelType);
+
     const photoURLs = calculatePhotoUrls(users);
     const isOnline = calculateOnlineStatus(users);
 

--- a/client/src/components/uis/MessageListItem.tsx
+++ b/client/src/components/uis/MessageListItem.tsx
@@ -28,6 +28,7 @@ const fragment = graphql`
       name
       nickname
       thumbURL
+      photoURL
       ...ProfileModal_user
     }
   }
@@ -260,7 +261,7 @@ const MessageListItem: FC<Props> = ({
             }}
           >
             <ImageSender
-              thumbURL={sender?.thumbURL}
+              thumbURL={sender?.thumbURL || sender?.photoURL}
               isSamePeerMsg={!!isPrevMessageSameUser}
               fontColor={theme.text}
             />

--- a/client/src/types/graphql.tsx
+++ b/client/src/types/graphql.tsx
@@ -19,7 +19,6 @@ export type Scalars = {
    * representation of dates and times using the Gregorian calendar.
    */
   Date: any;
-  DateTime: any;
   Gender: any;
   MembershipType: any;
   MessageType: any;
@@ -27,56 +26,48 @@ export type Scalars = {
   Upload: any;
 };
 
-
-
 export type AuthPayload = {
   __typename?: 'AuthPayload';
   token: Scalars['String'];
   user: User;
 };
 
-export type AuthType =
-  | 'email'
-  | 'facebook'
-  | 'google'
-  | 'apple';
-
 export type BlockedUser = {
   __typename?: 'BlockedUser';
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
-  user?: Maybe<User>;
   blockedUser?: Maybe<User>;
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  user?: Maybe<User>;
 };
 
 export type Channel = {
   __typename?: 'Channel';
-  id: Scalars['String'];
-  channelType: Scalars['ChannelType'];
-  name?: Maybe<Scalars['String']>;
-  lastMessageId?: Maybe<Scalars['String']>;
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
+  channelType?: Maybe<Scalars['ChannelType']>;
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
+  id: Scalars['ID'];
   /** Get latest message sent to the channel. */
   lastMessage?: Maybe<Message>;
-  messages?: Maybe<MessageConnection>;
+  lastMessageId?: Maybe<Scalars['String']>;
   /** Get memberships assigned to channel. If excludeMe is set, it will not return authenticated user. */
   memberships?: Maybe<Array<Membership>>;
-};
-
-
-export type ChannelMessagesArgs = {
-  first?: Maybe<Scalars['Int']>;
-  after?: Maybe<Scalars['String']>;
-  last?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['String']>;
+  messages?: Maybe<MessageConnection>;
+  name?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['Date']>;
 };
 
 
 export type ChannelMembershipsArgs = {
   excludeMe?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type ChannelMessagesArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
 };
 
 export type ChannelConnection = {
@@ -101,45 +92,40 @@ export type ChannelEdge = {
   node?: Maybe<Channel>;
 };
 
-
-
-
 export type Friend = {
   __typename?: 'Friend';
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
-  user?: Maybe<User>;
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
   friend?: Maybe<User>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  user?: Maybe<User>;
 };
-
 
 export type Membership = {
   __typename?: 'Membership';
   alertMode?: Maybe<Scalars['AlertMode']>;
-  membershipType?: Maybe<Scalars['MembershipType']>;
-  isVisible: Scalars['Boolean'];
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  user?: Maybe<User>;
   channel?: Maybe<Channel>;
+  createdAt?: Maybe<Scalars['Date']>;
+  isVisible?: Maybe<Scalars['Boolean']>;
+  membershipType?: Maybe<Scalars['MembershipType']>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  user?: Maybe<User>;
 };
-
 
 export type Message = {
   __typename?: 'Message';
-  id: Scalars['String'];
-  messageType: Scalars['MessageType'];
-  text?: Maybe<Scalars['String']>;
-  imageUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
-  fileUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
   channel?: Maybe<Channel>;
-  sender?: Maybe<User>;
-  replies?: Maybe<Array<Maybe<Reply>>>;
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
+  fileUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
+  id: Scalars['ID'];
+  imageUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
+  messageType: Scalars['MessageType'];
   reactions?: Maybe<Array<Maybe<Reaction>>>;
+  replies?: Maybe<Array<Maybe<Reply>>>;
+  sender?: Maybe<User>;
+  text?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['Date']>;
 };
 
 export type MessageConnection = {
@@ -151,10 +137,10 @@ export type MessageConnection = {
 };
 
 export type MessageCreateInput = {
+  fileUrls?: Maybe<Array<Scalars['String']>>;
+  imageUrls?: Maybe<Array<Scalars['String']>>;
   messageType?: Maybe<Scalars['MessageType']>;
   text?: Maybe<Scalars['String']>;
-  imageUrls?: Maybe<Array<Scalars['String']>>;
-  fileUrls?: Maybe<Array<Scalars['String']>>;
 };
 
 export type MessageEdge = {
@@ -165,24 +151,11 @@ export type MessageEdge = {
   node?: Maybe<Message>;
 };
 
-
 export type Mutation = {
   __typename?: 'Mutation';
-  signUp: User;
-  signInEmail: AuthPayload;
-  signInWithFacebook: AuthPayload;
-  signInWithApple: AuthPayload;
-  signInWithGoogle: AuthPayload;
-  sendVerification: Scalars['Boolean'];
-  /** Update user profile. Becareful that nullable fields will be updated either. */
-  updateProfile?: Maybe<User>;
-  findPassword: Scalars['Boolean'];
-  changeEmailPassword?: Maybe<Scalars['Boolean']>;
-  createNotification?: Maybe<Notification>;
-  deleteNotification?: Maybe<Notification>;
-  singleUpload: Scalars['String'];
   addFriend?: Maybe<Friend>;
-  deleteFriend?: Maybe<Friend>;
+  changeEmailPassword?: Maybe<Scalars['Boolean']>;
+  createBlockedUser?: Maybe<BlockedUser>;
   /**
    * Creates channel of [ChannelType].
    *   The private channel is unique by the unique members while
@@ -196,8 +169,20 @@ export type Mutation = {
    *   This query will return [Channel] with [Membership] without [Message] that has just created.
    */
   createChannel?: Maybe<Channel>;
+  createMessage?: Maybe<Message>;
+  createNotification?: Maybe<Notification>;
+  createReport?: Maybe<Report>;
+  deleteBlockedUser?: Maybe<BlockedUser>;
+  deleteFriend?: Maybe<Friend>;
+  deleteMessage?: Maybe<Message>;
+  deleteNotification?: Maybe<Notification>;
   /** Find or create channel associated to peer user id. */
   findOrCreatePrivateChannel?: Maybe<Channel>;
+  findPassword: Scalars['Boolean'];
+  /** Adds some users into [public] channel. */
+  inviteUsersToChannel?: Maybe<Channel>;
+  /** Removes some users from [public] channel. */
+  kickUsersFromChannel?: Maybe<Channel>;
   /**
    * User leaves [public] channel.
    *   Users cannot leave the [private] channel
@@ -206,81 +191,15 @@ export type Mutation = {
    *   User will leave the [public] channel and membership will be removed.
    */
   leaveChannel?: Maybe<Membership>;
-  /** Adds some users into [public] channel. */
-  inviteUsersToChannel?: Maybe<Channel>;
-  /** Removes some users from [public] channel. */
-  kickUsersFromChannel?: Maybe<Channel>;
-  createMessage?: Maybe<Message>;
-  deleteMessage?: Maybe<Message>;
-  createBlockedUser?: Maybe<BlockedUser>;
-  deleteBlockedUser?: Maybe<BlockedUser>;
-  createReport?: Maybe<Report>;
-};
-
-
-export type MutationSignUpArgs = {
-  photoUpload?: Maybe<Scalars['Upload']>;
-  user: UserCreateInput;
-};
-
-
-export type MutationSignInEmailArgs = {
-  email: Scalars['String'];
-  password: Scalars['String'];
-};
-
-
-export type MutationSignInWithFacebookArgs = {
-  accessToken: Scalars['String'];
-};
-
-
-export type MutationSignInWithAppleArgs = {
-  accessToken: Scalars['String'];
-};
-
-
-export type MutationSignInWithGoogleArgs = {
-  accessToken: Scalars['String'];
-};
-
-
-export type MutationSendVerificationArgs = {
-  email: Scalars['String'];
-};
-
-
-export type MutationUpdateProfileArgs = {
-  user: UserUpdateInput;
-};
-
-
-export type MutationFindPasswordArgs = {
-  email: Scalars['String'];
-};
-
-
-export type MutationChangeEmailPasswordArgs = {
-  password: Scalars['String'];
-  newPassword: Scalars['String'];
-};
-
-
-export type MutationCreateNotificationArgs = {
-  token: Scalars['String'];
-  device?: Maybe<Scalars['String']>;
-  os?: Maybe<Scalars['String']>;
-};
-
-
-export type MutationDeleteNotificationArgs = {
-  token: Scalars['String'];
-};
-
-
-export type MutationSingleUploadArgs = {
-  file: Scalars['Upload'];
-  dir?: Maybe<Scalars['String']>;
+  sendVerification: Scalars['Boolean'];
+  signInEmail: AuthPayload;
+  signInWithApple: AuthPayload;
+  signInWithFacebook: AuthPayload;
+  signInWithGoogle: AuthPayload;
+  signUp: User;
+  singleUpload: Scalars['String'];
+  /** Update user profile. Becareful that nullable fields will be updated either. */
+  updateProfile?: Maybe<User>;
 };
 
 
@@ -289,8 +208,14 @@ export type MutationAddFriendArgs = {
 };
 
 
-export type MutationDeleteFriendArgs = {
-  friendId: Scalars['String'];
+export type MutationChangeEmailPasswordArgs = {
+  newPassword: Scalars['String'];
+  password: Scalars['String'];
+};
+
+
+export type MutationCreateBlockedUserArgs = {
+  blockedUserId: Scalars['String'];
 };
 
 
@@ -300,13 +225,53 @@ export type MutationCreateChannelArgs = {
 };
 
 
+export type MutationCreateMessageArgs = {
+  channelId: Scalars['String'];
+  deviceKey: Scalars['String'];
+  message: MessageCreateInput;
+};
+
+
+export type MutationCreateNotificationArgs = {
+  device?: Maybe<Scalars['String']>;
+  os?: Maybe<Scalars['String']>;
+  token: Scalars['String'];
+};
+
+
+export type MutationCreateReportArgs = {
+  report: Scalars['String'];
+  reportedUserId: Scalars['String'];
+};
+
+
+export type MutationDeleteBlockedUserArgs = {
+  blockedUserId: Scalars['String'];
+};
+
+
+export type MutationDeleteFriendArgs = {
+  friendId: Scalars['String'];
+};
+
+
+export type MutationDeleteMessageArgs = {
+  id: Scalars['String'];
+};
+
+
+export type MutationDeleteNotificationArgs = {
+  token: Scalars['String'];
+};
+
+
 export type MutationFindOrCreatePrivateChannelArgs = {
   peerUserIds: Array<Scalars['String']>;
 };
 
 
-export type MutationLeaveChannelArgs = {
-  channelId: Scalars['String'];
+export type MutationFindPasswordArgs = {
+  email: Scalars['String'];
 };
 
 
@@ -322,110 +287,101 @@ export type MutationKickUsersFromChannelArgs = {
 };
 
 
-export type MutationCreateMessageArgs = {
+export type MutationLeaveChannelArgs = {
   channelId: Scalars['String'];
-  message: MessageCreateInput;
-  deviceKey: Scalars['String'];
 };
 
 
-export type MutationDeleteMessageArgs = {
-  id: Scalars['String'];
+export type MutationSendVerificationArgs = {
+  email: Scalars['String'];
 };
 
 
-export type MutationCreateBlockedUserArgs = {
-  blockedUserId: Scalars['String'];
+export type MutationSignInEmailArgs = {
+  email: Scalars['String'];
+  password: Scalars['String'];
 };
 
 
-export type MutationDeleteBlockedUserArgs = {
-  blockedUserId: Scalars['String'];
+export type MutationSignInWithAppleArgs = {
+  accessToken: Scalars['String'];
 };
 
 
-export type MutationCreateReportArgs = {
-  reportedUserId: Scalars['String'];
-  report: Scalars['String'];
+export type MutationSignInWithFacebookArgs = {
+  accessToken: Scalars['String'];
+};
+
+
+export type MutationSignInWithGoogleArgs = {
+  accessToken: Scalars['String'];
+};
+
+
+export type MutationSignUpArgs = {
+  photoUpload?: Maybe<Scalars['Upload']>;
+  user: UserCreateInput;
+};
+
+
+export type MutationSingleUploadArgs = {
+  dir?: Maybe<Scalars['String']>;
+  file: Scalars['Upload'];
+};
+
+
+export type MutationUpdateProfileArgs = {
+  user: UserUpdateInput;
 };
 
 export type Notification = {
   __typename?: 'Notification';
-  id: Scalars['Int'];
-  token: Scalars['String'];
+  createdAt?: Maybe<Scalars['Date']>;
   device?: Maybe<Scalars['String']>;
+  id: Scalars['Int'];
   os?: Maybe<Scalars['String']>;
-  user: User;
-  createdAt?: Maybe<Scalars['DateTime']>;
+  token: Scalars['String'];
 };
 
 /** PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
 export type PageInfo = {
   __typename?: 'PageInfo';
+  /** The cursor corresponding to the last nodes in edges. Null if the connection is empty. */
+  endCursor?: Maybe<Scalars['String']>;
   /** Used to indicate whether more edges exist following the set defined by the clients arguments. */
   hasNextPage: Scalars['Boolean'];
   /** Used to indicate whether more edges exist prior to the set defined by the clients arguments. */
   hasPreviousPage: Scalars['Boolean'];
   /** The cursor corresponding to the first nodes in edges. Null if the connection is empty. */
   startCursor?: Maybe<Scalars['String']>;
-  /** The cursor corresponding to the last nodes in edges. Null if the connection is empty. */
-  endCursor?: Maybe<Scalars['String']>;
 };
 
 export type Profile = {
   __typename?: 'Profile';
+  authType?: Maybe<Scalars['Auth']>;
   socialId?: Maybe<Scalars['String']>;
-  authType?: Maybe<AuthType>;
+  user?: Maybe<User>;
 };
 
 export type Query = {
   __typename?: 'Query';
+  /** Arguments are not needed. Only find blocked users of signed in user */
+  blockedUsers?: Maybe<Array<Maybe<User>>>;
+  /** Get single channel */
+  channel?: Maybe<Channel>;
+  channels?: Maybe<ChannelConnection>;
+  friends?: Maybe<UserConnection>;
+  /** Fetch current user profile when authenticated. */
+  me?: Maybe<User>;
+  /** Get single message */
+  message?: Maybe<Message>;
+  messages?: Maybe<MessageConnection>;
+  notifications?: Maybe<Array<Maybe<Notification>>>;
+  reports?: Maybe<Array<Maybe<Report>>>;
   /** Fetch user profile */
   user?: Maybe<User>;
   /** Query users with relay pagination. This is filterable but it will not return user itself and the blocked users. */
   users?: Maybe<UserConnection>;
-  /** Fetch current user profile when authenticated. */
-  me?: Maybe<User>;
-  notifications?: Maybe<Array<Maybe<Notification>>>;
-  friends?: Maybe<UserConnection>;
-  /** Get single channel */
-  channel?: Maybe<Channel>;
-  channels?: Maybe<ChannelConnection>;
-  /** Get single message */
-  message?: Maybe<Message>;
-  messages?: Maybe<MessageConnection>;
-  /** Arguments are not needed. Only find blocked users of signed in user */
-  blockedUsers?: Maybe<Array<Maybe<User>>>;
-  reports?: Maybe<Array<Maybe<Report>>>;
-};
-
-
-export type QueryUserArgs = {
-  id: Scalars['String'];
-};
-
-
-export type QueryUsersArgs = {
-  searchText?: Maybe<Scalars['String']>;
-  first?: Maybe<Scalars['Int']>;
-  after?: Maybe<Scalars['String']>;
-  last?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['String']>;
-};
-
-
-export type QueryNotificationsArgs = {
-  userId: Scalars['String'];
-};
-
-
-export type QueryFriendsArgs = {
-  searchText?: Maybe<Scalars['String']>;
-  includeMe?: Maybe<Scalars['Boolean']>;
-  first?: Maybe<Scalars['Int']>;
-  after?: Maybe<Scalars['String']>;
-  last?: Maybe<Scalars['Int']>;
-  before?: Maybe<Scalars['String']>;
 };
 
 
@@ -435,11 +391,21 @@ export type QueryChannelArgs = {
 
 
 export type QueryChannelsArgs = {
-  withMessage?: Maybe<Scalars['Boolean']>;
-  first?: Maybe<Scalars['Int']>;
   after?: Maybe<Scalars['String']>;
-  last?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  withMessage?: Maybe<Scalars['Boolean']>;
+};
+
+
+export type QueryFriendsArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  includeMe?: Maybe<Scalars['Boolean']>;
+  last?: Maybe<Scalars['Int']>;
+  searchText?: Maybe<Scalars['String']>;
 };
 
 
@@ -449,12 +415,17 @@ export type QueryMessageArgs = {
 
 
 export type QueryMessagesArgs = {
-  channelId: Scalars['String'];
-  searchText?: Maybe<Scalars['String']>;
-  first?: Maybe<Scalars['Int']>;
   after?: Maybe<Scalars['String']>;
-  last?: Maybe<Scalars['Int']>;
   before?: Maybe<Scalars['String']>;
+  channelId: Scalars['String'];
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  searchText?: Maybe<Scalars['String']>;
+};
+
+
+export type QueryNotificationsArgs = {
+  userId: Scalars['String'];
 };
 
 
@@ -462,40 +433,55 @@ export type QueryReportsArgs = {
   userId: Scalars['String'];
 };
 
+
+export type QueryUserArgs = {
+  id: Scalars['String'];
+};
+
+
+export type QueryUsersArgs = {
+  after?: Maybe<Scalars['String']>;
+  before?: Maybe<Scalars['String']>;
+  first?: Maybe<Scalars['Int']>;
+  last?: Maybe<Scalars['Int']>;
+  searchText?: Maybe<Scalars['String']>;
+};
+
 export type Reaction = {
   __typename?: 'Reaction';
-  id: Scalars['Int'];
+  id: Scalars['ID'];
   value: Scalars['String'];
 };
 
 export type Reply = {
   __typename?: 'Reply';
-  id: Scalars['Int'];
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
+  fileUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
+  id: Scalars['ID'];
+  imageUrls?: Maybe<Array<Maybe<Scalars['String']>>>;
   messageType: Scalars['MessageType'];
-  text?: Maybe<Scalars['String']>;
-  imageUrls: Array<Scalars['String']>;
-  fileUrls: Array<Scalars['String']>;
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
   sender: User;
+  text?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['Date']>;
 };
 
 export type Report = {
   __typename?: 'Report';
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
+  id: Scalars['ID'];
   report: Scalars['String'];
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
-  user?: Maybe<User>;
   reportedUser?: Maybe<User>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  user?: Maybe<User>;
 };
 
 export type Subscription = {
   __typename?: 'Subscription';
+  onMessage?: Maybe<Message>;
   userSignedIn?: Maybe<User>;
   userUpdated?: Maybe<User>;
-  onMessage?: Maybe<Message>;
 };
 
 
@@ -503,31 +489,30 @@ export type SubscriptionOnMessageArgs = {
   deviceKey: Scalars['String'];
 };
 
-
 export type User = {
   __typename?: 'User';
-  id: Scalars['String'];
+  birthday?: Maybe<Scalars['Date']>;
+  createdAt?: Maybe<Scalars['Date']>;
+  deletedAt?: Maybe<Scalars['Date']>;
   email?: Maybe<Scalars['String']>;
-  name?: Maybe<Scalars['String']>;
-  nickname?: Maybe<Scalars['String']>;
-  thumbURL?: Maybe<Scalars['String']>;
-  photoURL?: Maybe<Scalars['String']>;
-  birthday?: Maybe<Scalars['DateTime']>;
   gender?: Maybe<Scalars['Gender']>;
-  phone?: Maybe<Scalars['String']>;
-  statusMessage?: Maybe<Scalars['String']>;
-  verified?: Maybe<Scalars['Boolean']>;
-  lastSignedIn?: Maybe<Scalars['DateTime']>;
-  isOnline?: Maybe<Scalars['Boolean']>;
-  profile?: Maybe<Profile>;
-  createdAt?: Maybe<Scalars['DateTime']>;
-  updatedAt?: Maybe<Scalars['DateTime']>;
-  deletedAt?: Maybe<Scalars['DateTime']>;
-  notifications?: Maybe<Array<Maybe<Notification>>>;
   /** Check if the user is blocked by the user who have signed in. */
   hasBlocked?: Maybe<Scalars['Boolean']>;
+  id: Scalars['ID'];
   /** This user is a friend of the authenticated user. */
   isFriend?: Maybe<Scalars['Boolean']>;
+  isOnline?: Maybe<Scalars['Boolean']>;
+  lastSignedIn?: Maybe<Scalars['Date']>;
+  name?: Maybe<Scalars['String']>;
+  nickname?: Maybe<Scalars['String']>;
+  notifications?: Maybe<Array<Maybe<Notification>>>;
+  phone?: Maybe<Scalars['String']>;
+  photoURL?: Maybe<Scalars['String']>;
+  profile?: Maybe<Profile>;
+  statusMessage?: Maybe<Scalars['String']>;
+  thumbURL?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['Date']>;
+  verified?: Maybe<Scalars['Boolean']>;
 };
 
 export type UserConnection = {
@@ -539,12 +524,12 @@ export type UserConnection = {
 };
 
 export type UserCreateInput = {
+  birthday?: Maybe<Scalars['Date']>;
   email: Scalars['String'];
-  password: Scalars['String'];
+  gender?: Maybe<Scalars['Gender']>;
   name?: Maybe<Scalars['String']>;
   nickname?: Maybe<Scalars['String']>;
-  birthday?: Maybe<Scalars['Date']>;
-  gender?: Maybe<Scalars['Gender']>;
+  password: Scalars['String'];
   phone?: Maybe<Scalars['String']>;
   statusMessage?: Maybe<Scalars['String']>;
 };
@@ -558,13 +543,13 @@ export type UserEdge = {
 };
 
 export type UserUpdateInput = {
+  birthday?: Maybe<Scalars['Date']>;
   email?: Maybe<Scalars['String']>;
+  gender?: Maybe<Scalars['Gender']>;
   name?: Maybe<Scalars['String']>;
   nickname?: Maybe<Scalars['String']>;
-  thumbURL?: Maybe<Scalars['String']>;
-  photoURL?: Maybe<Scalars['String']>;
-  birthday?: Maybe<Scalars['Date']>;
   phone?: Maybe<Scalars['String']>;
+  photoURL?: Maybe<Scalars['String']>;
   statusMessage?: Maybe<Scalars['String']>;
-  gender?: Maybe<Scalars['Gender']>;
+  thumbURL?: Maybe<Scalars['String']>;
 };

--- a/server/src/resolvers/Channel/query.ts
+++ b/server/src/resolvers/Channel/query.ts
@@ -64,9 +64,11 @@ export const channels = queryField((t) => {
         orderBy: {updatedAt: 'desc'},
       });
 
-      return rows.filter(
-        (el) => (el._count || 0) > 1 && el.channelType !== 'self',
+      const result = rows.filter(
+        (el) => (el._count?.membership || 0) > 1 && el.channelType !== 'self',
       );
+
+      return result;
     },
   });
 });

--- a/server/src/resolvers/Channel/query.ts
+++ b/server/src/resolvers/Channel/query.ts
@@ -37,7 +37,7 @@ export const channels = queryField((t) => {
         },
       };
 
-      return prisma.channel.findMany({
+      const rows = await prisma.channel.findMany({
         ...relayToPrismaPagination({
           after,
           before,
@@ -55,8 +55,18 @@ export const channels = queryField((t) => {
           ...checkMessage,
         },
 
+        include: {
+          _count: {
+            select: {membership: true},
+          },
+        },
+
         orderBy: {updatedAt: 'desc'},
       });
+
+      return rows.filter(
+        (el) => (el._count || 0) > 1 && el.channelType !== 'self',
+      );
     },
   });
 });

--- a/server/tests/resolvers/channel.test.ts
+++ b/server/tests/resolvers/channel.test.ts
@@ -201,17 +201,21 @@ describe('Resolver - Channel', () => {
     channels.push(response.createChannel.id);
   });
 
-  it('should query my channels which are newly inserted in above tests === 3', async () => {
-    const response = await authClient.request(channelsQuery);
+  it(
+    'should query my channels which are newly inserted in above tests === 3, ' +
+      'however result will be equal to 2 since one of them has only one user in `memberships`',
+    async () => {
+      const response = await authClient.request(channelsQuery);
 
-    expect(response).toHaveProperty('channels');
-    expect(response.channels.edges).toHaveLength(3);
-    expect(channels.length).toEqual(response.channels.edges.length);
+      expect(response).toHaveProperty('channels');
+      expect(response.channels.edges).toHaveLength(2);
+      expect(channels.length).toEqual(response.channels.edges.length + 1);
 
-    response.channels.edges.forEach((channelEdge) => {
-      expect(channels).toContain(channelEdge.node.id);
-    });
-  });
+      response.channels.edges.forEach((channelEdge) => {
+        expect(channels).toContain(channelEdge.node.id);
+      });
+    },
+  );
 
   it('should query single channel with channelId', async () => {
     const variables = {


### PR DESCRIPTION
## Specify project
Server

## Description

Currently there is a problem when removing channel. We get `membership` of length less than 2 which does not return user when rendering channels.

We can filter the channel on the server side to avoid current situation.

- Rregenerated schema and typings.

## Related Issues

N/A

## Tests

Update channels query result after inserting since the number of channels will not be identical. The `memberships` length with less than 2 will not be shown.

- Update snapshots

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
