### PR TITLE
Resolve a [react-navigation] error in LicenseAgreement page

### DIFF
--- a/client/src/components/pages/LicenseAgreement.tsx
+++ b/client/src/components/pages/LicenseAgreement.tsx
@@ -1,4 +1,4 @@
-import React, {FC, ReactElement, memo, useLayoutEffect} from 'react';
+import React, {FC, ReactElement, useCallback, useLayoutEffect} from 'react';
 import {ScrollView, Text, TouchableOpacity, View} from 'react-native';
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -25,39 +25,36 @@ const Page: FC = () => {
   const navigation = useNavigation<RootStackNavigationProps<'default'>>();
   const {theme} = useTheme();
 
-  const pressAgree = async (): Promise<void> => {
+  const pressAgree = useCallback(async (): Promise<void> => {
     await AsyncStorage.setItem('license_agreed', JSON.stringify(true));
     navigation.pop();
-  };
-
-  const headerRight = memo(
-    (): ReactElement => (
-      <TouchableOpacity testID="touch-done" onPress={pressAgree}>
-        <View
-          style={{
-            paddingHorizontal: 16,
-            paddingVertical: 8,
-          }}
-        >
-          <Text
-            style={{
-              color: theme.text,
-              fontSize: 14,
-              fontWeight: 'bold',
-            }}
-          >
-            {getString('AGREE')}
-          </Text>
-        </View>
-      </TouchableOpacity>
-    ),
-  );
+  }, [navigation]);
 
   useLayoutEffect(() => {
     navigation.setOptions({
-      headerRight,
+      // eslint-disable-next-line react/no-unstable-nested-components
+      headerRight: (): ReactElement => (
+        <TouchableOpacity testID="touch-done" onPress={pressAgree}>
+          <View
+            style={{
+              paddingHorizontal: 16,
+              paddingVertical: 8,
+            }}
+          >
+            <Text
+              style={{
+                color: theme.text,
+                fontSize: 14,
+                fontWeight: 'bold',
+              }}
+            >
+              {getString('AGREE')}
+            </Text>
+          </View>
+        </TouchableOpacity>
+      ),
     });
-  }, [headerRight, navigation]);
+  }, [pressAgree, navigation, theme.text]);
 
   return (
     <Container>


### PR DESCRIPTION
## Specify project
`react-native`

## Description

`headerRight` function in `LicenseAgreement` page make an error like below.
```
react natvigation TypeError: right is not a function.
```

So I placed it into the `useLayoutEffect` hook, then the error was disappeared.

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
