### PR TITLE
Implement delete user mutation

### DIFF
--- a/server/src/resolvers/User/mutation.ts
+++ b/server/src/resolvers/User/mutation.ts
@@ -7,7 +7,14 @@ import {
 } from '../../utils/error';
 import SendGridMail, {MailDataRequired} from '@sendgrid/mail';
 import {andThen, pipe} from 'ramda';
-import {arg, inputObjectType, mutationField, nonNull, stringArg} from 'nexus';
+import {
+  arg,
+  idArg,
+  inputObjectType,
+  mutationField,
+  nonNull,
+  stringArg,
+} from 'nexus';
 import {
   encryptCredential,
   getEmailVerificationHTML,
@@ -418,6 +425,21 @@ export const changeEmailPassword = mutationField('changeEmailPassword', {
         where: {id: userId},
         data: {password: newPassword},
       });
+
+      return true;
+    } catch (err: any) {
+      throw new Error(err.message);
+    }
+  },
+});
+
+export const deleteUser = mutationField('deleteUser', {
+  type: nonNull('Boolean'),
+  args: {id: nonNull(idArg())},
+
+  resolve: async (_parent, {id}, ctx) => {
+    try {
+      await ctx.prisma.user.delete({where: {id}});
 
       return true;
     } catch (err: any) {

--- a/server/tests/queries/User.ts
+++ b/server/tests/queries/User.ts
@@ -80,6 +80,12 @@ export const updateProfileMutation = /* GraphQL */ `
   }
 `;
 
+export const deleteUserMutation = /* GraphQL */ `
+  mutation deleteUser($id: ID!) {
+    deleteUser(id: $id)
+  }
+`;
+
 export const meQuery = /* GraphQL */ `
   query me {
     me {

--- a/server/tests/resolvers/user.test.ts
+++ b/server/tests/resolvers/user.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 import {
+  deleteUserMutation,
   findPasswordMutation,
   signInEmailMutation,
   signUpMutation,
@@ -59,7 +60,7 @@ describe('Resolver - User', () => {
 
     try {
       await graphqlClient.request(findPasswordMutation, variableNotExist);
-    } catch (e) {
+    } catch (e: any) {
       const response = e.response;
 
       expect(response.errors[0].message).toEqual(
@@ -73,7 +74,7 @@ describe('Resolver - User', () => {
 
     try {
       await graphqlClient.request(findPasswordMutation, variableNotValid);
-    } catch (e) {
+    } catch (e: any) {
       const response = e.response;
 
       expect(response.errors[0].message).toEqual(
@@ -87,7 +88,7 @@ describe('Resolver - User', () => {
 
     try {
       await graphqlClient.request(findPasswordMutation, variableValidUser);
-    } catch (e) {
+    } catch (e: any) {
       const response = e.response;
 
       expect(response.errors[0].message).toEqual(
@@ -96,6 +97,19 @@ describe('Resolver - User', () => {
     }
   });
 
+  it('should remove user', async () => {
+    const {graphqlClient, prisma} = getTestUtils();
+
+    const user = await prisma.user.findUnique({
+      where: {email: userVariables.user.email},
+    });
+
+    const response = await graphqlClient.request(deleteUserMutation, {
+      id: user?.id,
+    });
+
+    expect(response.deleteUser).toBeTruthy();
+  });
   // Hyo => https://github.com/apollographql/subscriptions-transport-ws/issues/872
 
   // describe('Resolver - after signInEmail', () => {


### PR DESCRIPTION
## Specify project
server

## Description

Meta and other auth providers changed their privacy policy. One of the important changes is that A user should have the right to request for their data deletion. So We need the `deleteUser` mutation.

## Related Issues

N/A

## Tests

Add test case in `user.test.ts`

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/dooboolab/hackatalk/blob/master/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
